### PR TITLE
Changed Page<T> BuildPageQuery and Count logic to make more general.

### DIFF
--- a/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
+++ b/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
@@ -4,45 +4,44 @@ using System.Linq;
 
 namespace NPoco.DatabaseTypes
 {
-    public class SqlServerDatabaseType : DatabaseType
-    {
-        public override string BuildPageQuery(long skip, long take, PagingHelper.SQLParts parts, ref object[] args)
-        {
-            parts.sqlSelectRemoved = PagingHelper.rxOrderBy.Replace(parts.sqlSelectRemoved, "", 1);
-            var sqlPage = string.Format("SELECT * FROM (SELECT ROW_NUMBER() OVER ({0}) peta_rn, {1}) peta_paged WHERE peta_rn>@{2} AND peta_rn<=@{3}",
-                                        parts.sqlOrderBy ?? "ORDER BY (SELECT NULL /*poco_dual*/)", parts.sqlSelectRemoved, args.Length, args.Length + 1);
-            args = args.Concat(new object[] { skip, skip + take }).ToArray();
+	public class SqlServerDatabaseType : DatabaseType
+	{
+		public override string BuildPageQuery(long skip, long take, PagingHelper.SQLParts parts, ref object[] args)
+		{
+			var sqlPage = string.Format("SELECT * FROM (SELECT ROW_NUMBER() OVER ({0}) peta_rn, * FROM ({1}) peta_base) peta_paged WHERE peta_rn>{2} AND peta_rn<={3}",
+																	parts.sqlOrderBy ?? "ORDER BY (SELECT NULL /*poco_dual*/)", parts.sqlUnordered, skip, skip + take);
+			args = args.Concat(new object[] { skip, skip + take }).ToArray();
 
-            return sqlPage;
-        }
+			return sqlPage;
+		}
 
-        public override object ExecuteInsert<T>(Database db, IDbCommand cmd, string primaryKeyName, T poco, object[] args)
-        {
-            //var pocodata = PocoData.ForType(typeof(T), db.PocoDataFactory);
-            //var sql = string.Format("SELECT * FROM {0} WHERE {1} = SCOPE_IDENTITY()", EscapeTableName(pocodata.TableInfo.TableName), EscapeSqlIdentifier(primaryKeyName));
-            //return db.SingleInto(poco, ";" + cmd.CommandText + ";" + sql, args);
-            cmd.CommandText += ";SELECT SCOPE_IDENTITY();";
-            return db.ExecuteScalarHelper(cmd);
-        }
+		public override object ExecuteInsert<T>(Database db, IDbCommand cmd, string primaryKeyName, T poco, object[] args)
+		{
+				//var pocodata = PocoData.ForType(typeof(T), db.PocoDataFactory);
+				//var sql = string.Format("SELECT * FROM {0} WHERE {1} = SCOPE_IDENTITY()", EscapeTableName(pocodata.TableInfo.TableName), EscapeSqlIdentifier(primaryKeyName));
+				//return db.SingleInto(poco, ";" + cmd.CommandText + ";" + sql, args);
+				cmd.CommandText += ";SELECT SCOPE_IDENTITY();";
+				return db.ExecuteScalarHelper(cmd);
+		}
 
-        public override string GetExistsSql()
-        {
-            return "IF EXISTS (SELECT 1 FROM {0} WHERE {1}) SELECT 1 ELSE SELECT 0";
-        }
+		public override string GetExistsSql()
+		{
+				return "IF EXISTS (SELECT 1 FROM {0} WHERE {1}) SELECT 1 ELSE SELECT 0";
+		}
 
-        public override void InsertBulk<T>(IDatabase db, IEnumerable<T> pocos)
-        {
-            SqlBulkCopyHelper.BulkInsert(db, pocos);
-        }
+		public override void InsertBulk<T>(IDatabase db, IEnumerable<T> pocos)
+		{
+				SqlBulkCopyHelper.BulkInsert(db, pocos);
+		}
 
-        public override IsolationLevel GetDefaultTransactionIsolationLevel()
-        {
-            return IsolationLevel.ReadCommitted;
-        }
+		public override IsolationLevel GetDefaultTransactionIsolationLevel()
+		{
+				return IsolationLevel.ReadCommitted;
+		}
 
-        public override string GetProviderName()
-        {
-            return "System.Data.SqlClient";
-        }
-    }
+		public override string GetProviderName()
+		{
+				return "System.Data.SqlClient";
+		}
+	}
 }

--- a/src/NPoco/PagerHelper.cs
+++ b/src/NPoco/PagerHelper.cs
@@ -1,56 +1,57 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Data;
+using System.Text.RegularExpressions;
 
 namespace NPoco
 {
-    public class PagingHelper
-    {
-        public static Regex rxColumns = new Regex(@"\A\s*SELECT\s+((?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|.)*?)(?<!,\s+)\bFROM\b", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
-        public static Regex rxOrderBy = new Regex(@"\bORDER\s+BY\s+(?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|[\w\(\)\.\[\]""`])+(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|[\w\(\)\.\[\]""`])+(?:\s+(?:ASC|DESC))?)*", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
-        public static Regex rxDistinct = new Regex(@"\ADISTINCT\s", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
+	public class PagingHelper
+	{
+		public static Regex rxColumns = new Regex(@"\A\s*SELECT\s+((?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|.)*?)(?<!,\s+)\bFROM\b", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
+		//Not working: public static Regex rxColumns = new Regex(@"\A\s*SELECT\s+[^,]*((?:\s+[^,\s]+\s*,)*(?:\s+[^,\s]+\s+(?=[^,\s])))(INTO\s+\S+\s+)?FROM\b", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
+		public static Regex rxOrderBy = new Regex(@"\bORDER\s+BY\s+(?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|[\w\(\)\.\[\]""`])+(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:\((?>\((?<depth>)|\)(?<-depth>)|.?)*(?(depth)(?!))\)|[\w\(\)\.\[\]""`])+(?:\s+(?:ASC|DESC))?)*", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
+		//public static Regex rxDistinct = new Regex(@"\ADISTINCT\s", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline | RegexOptions.Compiled);
 
-        public struct SQLParts
-        {
-            public string sql;
-            public string sqlCount;
-            public string sqlSelectRemoved;
-            public string sqlOrderBy;
-        }
+		public struct SQLParts
+		{
+			public string sql;
+			public string sqlCount;
+			public string sqlSelectRemoved;
+			public string sqlOrderBy;
+			public string sqlUnordered;
+		}
 
-        public static bool SplitSQL(string sql, out SQLParts parts)
-        {
-            parts.sql = sql;
-            parts.sqlSelectRemoved = null;
-            parts.sqlCount = null;
-            parts.sqlOrderBy = null;
+		public static bool SplitSQL(string sql, out SQLParts parts)
+		{
+			parts.sql = sql;
+			parts.sqlSelectRemoved = null;
+			parts.sqlCount = null;
+			parts.sqlOrderBy = null;
+			parts.sqlUnordered = sql.Trim().Trim(';');
 
-            // Extract the columns from "SELECT <whatever> FROM"
-            var m = rxColumns.Match(sql);
-            if (!m.Success)
-                return false;
+			// Extract the columns from "SELECT <whatever> FROM"
+			var m = rxColumns.Match(sql);
+			if (!m.Success) return false;
 
-            // Save column list and replace with COUNT(*)
-            Group g = m.Groups[1];
-            parts.sqlSelectRemoved = sql.Substring(g.Index);
+			// Save column list  [and replace with COUNT(*)]
+			Group g = m.Groups[1];
+			parts.sqlSelectRemoved = sql.Substring(g.Index);
 
-            if (rxDistinct.IsMatch(parts.sqlSelectRemoved))
-            {
-                parts.sqlCount = sql.Substring(0, g.Index) + "COUNT(" + m.Groups[1].ToString().Trim() + ") " + sql.Substring(g.Index + g.Length);
-            }
-            else
-            {
-                parts.sqlCount = sql.Substring(0, g.Index) + "COUNT(*) " + sql.Substring(g.Index + g.Length);
-            }
+			// Look for the last "ORDER BY <whatever>" clause not part of a ROW_NUMBER expression
+			m = rxOrderBy.Match(parts.sql);
+			if (m.Success)
+			{
+				g = m.Groups[0];
+				parts.sqlOrderBy = g.ToString();
+				parts.sqlUnordered = parts.sqlUnordered.Replace(parts.sqlOrderBy, "");
+			}
+			else
+			{
+				throw new DataException("ORDER BY required for paged query.");
+			}
 
-            // Look for the last "ORDER BY <whatever>" clause not part of a ROW_NUMBER expression
-            m = rxOrderBy.Match(parts.sqlCount);
-            if (m.Success)
-            {
-                g = m.Groups[0];
-                parts.sqlOrderBy = g.ToString();
-                parts.sqlCount = parts.sqlCount.Substring(0, g.Index) + parts.sqlCount.Substring(g.Index + g.Length);
-            }
-
-            return true;
-        }
-    }
+			parts.sqlCount = string.Format(@"SELECT COUNT(*) FROM ({0}) peta_tbl", parts.sqlUnordered);
+			
+			return true;
+		}
+	}
 }


### PR DESCRIPTION
Did not seem to be working; now passes all tests, including new tests
using queries on a test table with results narrowed by the DISTINCT keyword.

To generate a pageable result set, I take the original SELECT query, strip the final ORDER BY clause and use it as a subquery within the logic to generate the row numbers.  The prior logic stripping the front of the select clause seemed to be erroring out and I think would give the wrong results in a query using (and needing) DISTINCT.

Please let me know if I have done something boneheaded.  Thanks, Bob
