### PR TITLE
Guid should be treated as such DbType.

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -407,8 +407,8 @@ namespace NPoco
                 }
                 else if (t == typeof(Guid))
                 {
-                    p.Value = value.ToString();
-                    p.DbType = DbType.String;
+                    p.Value = value;
+                    p.DbType = DbType.Guid;
                     p.Size = 40;
                 }
                 else if (t == typeof(string))


### PR DESCRIPTION
Using NPoco with PostgreSQL (npgsql) the following was not possible:

```
database.Fetch<Table>("select * from table where guidcol=@0", myGuid);
```

I got a NpgsqlException: "ERROR: 42883: operator does not exist: uuid = text"

This was because NPoco tried to execute the following SQL:

select \* from table where guidcol=((E'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')::text)

This fixes it, and I don't see any unit tests failing, so I'm not sure why the original code was to treat Guid as DbType.String.
