### PR TITLE
Add support for decimal type.

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -459,6 +459,11 @@ namespace NPoco
                     p.GetType().GetProperty("UdtTypeName").SetValue(p, "geometry", null); //geography is the equivalent SQL Server Type
                     p.Value = value;
                 }
+                else if (t == typeof(decimal))
+                {
+                    p.Value = value;
+                    p.DbType = DbType.Decimal;
+                }
                 else
                 {
                     p.Value = value;


### PR DESCRIPTION
Problem code:

  var entity = new Entity { DecimalColumn = 0.05m };
  database.Insert(entity);

This would work but when looking at the contents in the table, the value was changed to 5.0.

This pull request fixes it.
