### PR TITLE
FetchMultiple returning unlimited number of types (1/2)

### DIFF
--- a/src/NPoco/IDatabaseQuery.cs
+++ b/src/NPoco/IDatabaseQuery.cs
@@ -89,5 +89,6 @@ namespace NPoco
         Tuple<List<T1>, List<T2>, List<T3>> FetchMultiple<T1, T2, T3>(Sql sql);
         Tuple<List<T1>, List<T2>, List<T3>, List<T4>> FetchMultiple<T1, T2, T3, T4>(Sql sql);
 
+        Dictionary<Type, List<object>> FetchMultiple(Sql Sql, params Type[] types);
     }
 }


### PR DESCRIPTION
This change is intended to remove the current limit of the max of four types returned by FetchMultiple overloads. Types expected to be created are provided in the second argument and their precise order in the array must match the multiple resultsets returned by the SQL query. The method's return value is a dictionary whose keys are the types returned and elements contain lists of objects created from resultset rows.
