### PR TITLE
Update SQLiteDatabaseType.cs

### DIFF
--- a/src/NPoco/DatabaseTypes/SQLiteDatabaseType.cs
+++ b/src/NPoco/DatabaseTypes/SQLiteDatabaseType.cs
@@ -48,5 +48,10 @@ namespace NPoco.DatabaseTypes
                     return "SET TRANSACTION ISOLATION LEVEL READ COMMITTED;";
             }
         }
+        
+        public override string GetProviderName()
+        {
+            return "System.Data.SQLite";
+        }        
     }
 }


### PR DESCRIPTION
Fixed fault where GetProviderName was returning SQL Server rather than SQLite when using SQLite.
