### PR TITLE
ExplicitColumns ApplyToBase flag

### DIFF
--- a/src/NPoco.Tests/Common/UserDecorated.cs
+++ b/src/NPoco.Tests/Common/UserDecorated.cs
@@ -101,4 +101,33 @@ namespace NPoco.Tests.Common
     }
 
     public enum Days : byte { Sat, Sun, Mon, Tue, Wed, Thu, Fri };
+
+    public class UserDecoratedBase
+    {
+        public bool IgnoreMe { get; set; }
+    }
+
+    [TableName("Users")]
+    [PrimaryKey("UserId")]
+    [ExplicitColumns(ApplyToBase = true)]
+    public class UserDecoratedDerived : UserDecoratedBase
+    {
+        [Column("UserId")]
+        public int UserId { get; set; }
+
+        [Column("Name")]
+        public string Name { get; set; }
+
+        [Column("Age")]
+        public int Age { get; set; }
+
+        [Column("DateOfBirth")]
+        public DateTime DateOfBirth { get; set; }
+
+        [Column("Savings")]
+        public decimal Savings { get; set; }
+
+        [Column("is_male")]
+        public bool IsMale { get; set; }
+    }
 }

--- a/src/NPoco.Tests/FluentTests/QueryTests/FetchAndQueryFluentTest.cs
+++ b/src/NPoco.Tests/FluentTests/QueryTests/FetchAndQueryFluentTest.cs
@@ -109,5 +109,23 @@ namespace NPoco.Tests.FluentTests.QueryTests
             Assert.AreEqual(2, data[0]["userid"]);
             Assert.AreEqual("Name2", data[0]["name"]);
         }
+
+        [Test]
+        public void FetchAllIgnoreBase()
+        {
+            var users = Database.Fetch<UserDecoratedDerived>();
+
+            Assert.AreEqual(InMemoryUsers.Count, users.Count);
+            for (int i = 0; i < InMemoryUsers.Count; i++)
+            {
+                User expected = InMemoryUsers[i];
+                UserDecoratedDerived actual = users[i];
+                Assert.AreEqual(expected.UserId, actual.UserId);
+                Assert.AreEqual(expected.Name, actual.Name);
+                Assert.AreEqual(expected.Age, actual.Age);
+                Assert.AreEqual(expected.DateOfBirth, actual.DateOfBirth);
+                Assert.AreEqual(expected.Savings, actual.Savings);
+            }
+        }
     }
 }

--- a/src/NPoco/ColumnInfo.cs
+++ b/src/NPoco/ColumnInfo.cs
@@ -15,8 +15,10 @@ namespace NPoco
 
         public static ColumnInfo FromMemberInfo(MemberInfo mi)
         {
-            // Check if declaring poco has [Explicit] attribute
-            bool ExplicitColumns = mi.DeclaringType.GetCustomAttributes(typeof(ExplicitColumnsAttribute), true).Length > 0;
+            // Check if declaring/reflected poco has [Explicit] attribute
+            var a = mi.ReflectedType.GetCustomAttributes(typeof(ExplicitColumnsAttribute), true);
+            bool ExplicitColumns = mi.DeclaringType.GetCustomAttributes(typeof(ExplicitColumnsAttribute), true).Any()
+                || a.Length != 0 && (a[0] as ExplicitColumnsAttribute).ApplyToBase;
 
             // Check for [Column]/[Ignore] Attributes
             var ColAttrs = mi.GetCustomAttributes(typeof(ColumnAttribute), true);

--- a/src/NPoco/ExplicitColumnsAttribute.cs
+++ b/src/NPoco/ExplicitColumnsAttribute.cs
@@ -5,5 +5,6 @@ namespace NPoco
     [AttributeUsage(AttributeTargets.Class)]
     public class ExplicitColumnsAttribute : Attribute
     {
+        public bool ApplyToBase { get; set; }
     }
 }


### PR DESCRIPTION
Useful if POCO's base class exposes columns we don't want to auto-select.