### PR TITLE
Create ComputedColumn Attribute

### DIFF
--- a/src/NPoco/ColumnInfo.cs
+++ b/src/NPoco/ColumnInfo.cs
@@ -10,6 +10,7 @@ namespace NPoco
     {
         public string ColumnName { get; set; }
         public bool ResultColumn { get; set; }
+        public bool ComputedColumn { get; set; }
         public bool IgnoreColumn { get; set; }
         public bool ForceToUtc { get; set; }
         public Type ColumnType { get; set; }
@@ -41,12 +42,14 @@ namespace NPoco
                 ci.ColumnName = colattr.Name ?? mi.Name;
                 ci.ForceToUtc = colattr.ForceToUtc;
                 ci.ResultColumn = colattr is ResultColumnAttribute;
+                ci.ComputedColumn = colattr is ComputedColumnAttribute;
             }
             else
             {
                 ci.ColumnName = mi.Name;
                 ci.ForceToUtc = false;
                 ci.ResultColumn = false;
+                ci.ComputedColumn = false;
             }
 
             if (columnTypeAttrs.Any())

--- a/src/NPoco/ComputedColumnAttribute.cs
+++ b/src/NPoco/ComputedColumnAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NPoco
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class ComputedColumnAttribute : ColumnAttribute
+    {
+        public ComputedColumnAttribute() { }
+        public ComputedColumnAttribute(string name) : base(name) { }
+    }
+}

--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -1241,6 +1241,10 @@ namespace NPoco
                     if (i.Value.ResultColumn)
                         continue;
 
+                    // Don't insert computed columns
+                    if (i.Value.ComputedColumn)
+                        continue;
+
                     // Don't insert the primary key (except under oracle where we need bring in the next sequence value)
                     if (autoIncrement && primaryKeyName != null && string.Compare(i.Key, primaryKeyName, true) == 0)
                     {
@@ -1393,6 +1397,10 @@ namespace NPoco
 
                 // Dont update result only columns
                 if (i.Value.ResultColumn)
+                    continue;
+
+                // Dont update computed columns
+                if (i.Value.ComputedColumn)
                     continue;
 
                 if (!i.Value.VersionColumn && columns != null && !columns.Contains(i.Value.ColumnName, StringComparer.OrdinalIgnoreCase))

--- a/src/NPoco/NPoco.csproj
+++ b/src/NPoco/NPoco.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ColumnAttribute.cs" />
     <Compile Include="ColumnInfo.cs" />
     <Compile Include="ColumnTypeAttribute.cs" />
+    <Compile Include="ComputedColumnAttribute.cs" />
     <Compile Include="Database.cs" />
     <Compile Include="DatabaseFactory.cs" />
     <Compile Include="DatabaseFactoryConfig.cs" />

--- a/src/NPoco/PocoColumn.cs
+++ b/src/NPoco/PocoColumn.cs
@@ -14,6 +14,7 @@ namespace NPoco
         public string ColumnName;
         public MemberInfo MemberInfo;
         public bool ResultColumn;
+        public bool ComputedColumn;
         public bool VersionColumn;
         private Type _columnType;
         public Type ColumnType

--- a/src/NPoco/PocoData.cs
+++ b/src/NPoco/PocoData.cs
@@ -58,6 +58,7 @@ namespace NPoco
                 pc.MemberInfo = mi;
                 pc.ColumnName = ci.ColumnName;
                 pc.ResultColumn = ci.ResultColumn;
+                pc.ComputedColumn = ci.ComputedColumn;
                 pc.ForceToUtc = ci.ForceToUtc;
                 pc.ColumnType = ci.ColumnType;
 


### PR DESCRIPTION
Create a `[ComputedColumn]` Attribute. Like `[ResultColumn]`, a column
having this attribute will be skipped during inserts and updates, _but_ it
**will** be included in selects without requiring explicit inclusion. These
would be essentially read-only columns, not just ignored columns.
