### PR TITLE
Add shortcut database method to update snapshotted pocos

### DIFF
--- a/src/NPoco/Snapshotter.cs
+++ b/src/NPoco/Snapshotter.cs
@@ -14,6 +14,11 @@ namespace NPoco
         {
             return new Snapshot<T>(d, obj);
         }
+
+        public static int Update<T>(this IDatabase d, T obj, Snapshot<T> snapshot)
+        {
+            return d.Update(obj, snapshot.UpdatedColumns());
+        }
     }
 
     public class Snapshot<T>


### PR DESCRIPTION
Added a shortcut method so that database update calls can take in the snapshot directly instead of having to retrieve the list of snapshot.Changes() as the second param
