### PR TITLE
Issue #116 - Make CreateCommand public

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -519,7 +519,7 @@ namespace NPoco
         }
 
         // Create a command
-        IDbCommand CreateCommand(IDbConnection connection, string sql, params object[] args)
+        public IDbCommand CreateCommand(IDbConnection connection, string sql, params object[] args)
         {
             // Perform parameter prefix replacements
             if (_paramPrefix != "@")


### PR DESCRIPTION
In my use of PetaPoco I rely on this method being public.  

I have tried to work around the fact that is internal, but I need to access teh command object so I can call ExecuteReader and worjk directly with the IDataReader for a few scenarios where I cannot use mapping.
