### PR TITLE
Non parameterized queries can cause high memory usage

### DIFF
--- a/src/NPoco.Tests/HashCodeCombinerTests.cs
+++ b/src/NPoco.Tests/HashCodeCombinerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace NPoco.Tests
+{
+    [TestFixture]
+    public class HashCodeCombinerTests
+    {
+
+        [Test]
+        public void HashCombiner_Test_String()
+        {
+            var combiner1 = new HashCodeCombiner();
+            combiner1.AddCaseInsensitiveString("Hello");
+
+            var combiner2 = new HashCodeCombiner();
+            combiner2.AddCaseInsensitiveString("hello");
+
+            Assert.AreEqual(combiner1.GetCombinedHashCode(), combiner2.GetCombinedHashCode());
+
+            combiner2.AddCaseInsensitiveString("world");
+
+            Assert.AreNotEqual(combiner1.GetCombinedHashCode(), combiner2.GetCombinedHashCode());
+        }
+
+        [Test]
+        public void HashCombiner_Test_Int()
+        {
+            var combiner1 = new HashCodeCombiner();
+            combiner1.AddInt(1234);
+
+            var combiner2 = new HashCodeCombiner();
+            combiner2.AddInt(1234);
+
+            Assert.AreEqual(combiner1.GetCombinedHashCode(), combiner2.GetCombinedHashCode());
+
+            combiner2.AddInt(1);
+
+            Assert.AreNotEqual(combiner1.GetCombinedHashCode(), combiner2.GetCombinedHashCode());
+        }
+
+    }
+}

--- a/src/NPoco.Tests/NPoco.Tests.csproj
+++ b/src/NPoco.Tests/NPoco.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="FluentTests\QueryTests\PagingFluentTest.cs" />
     <Compile Include="FluentTests\QueryTests\SingleAndFirstQueryFluentTest.cs" />
     <Compile Include="FormatCommandTest.cs" />
+    <Compile Include="HashCodeCombinerTests.cs" />
     <Compile Include="PagingHelper.cs" />
     <Compile Include="PocoExpandoTests.cs" />
     <Compile Include="SnapshotterTests.cs" />

--- a/src/NPoco/Cache.cs
+++ b/src/NPoco/Cache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Caching;
 using System.Text;
 using System.Threading;
 
@@ -8,8 +9,30 @@ namespace NPoco
 {
     internal class Cache<TKey, TValue>
     {
+        private readonly bool _useManaged;
+
+        private Cache(bool useManaged)
+        {
+            _useManaged = useManaged;
+        }
+
+        /// <summary>
+        /// Creates a cache that uses static storage
+        /// </summary>
+        /// <returns></returns>
+        public static Cache<TKey, TValue> CreateStaticCache()
+        {
+            return new Cache<TKey, TValue>(false);
+        }
+
+        public static Cache<TKey, TValue> CreateManagedCache()
+        {
+            return new Cache<TKey, TValue>(true);
+        }
+
         Dictionary<TKey, TValue> _map = new Dictionary<TKey, TValue>();
         ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+        ObjectCache _objectCache = new MemoryCache("NPoco");
 
         public int Count
         {
@@ -21,6 +44,20 @@ namespace NPoco
 
         public TValue Get(TKey key, Func<TValue> factory)
         {
+            if (_useManaged)
+            {
+                //lazy usage of AddOrGetExisting ref: http://stackoverflow.com/questions/10559279/how-to-deal-with-costly-building-operations-using-memorycache/15894928#15894928
+                var newValue = new Lazy<TValue>(factory);
+                // the line belows returns existing item or adds the new value if it doesn't exist
+                var value = (Lazy<TValue>)_objectCache.AddOrGetExisting(key.ToString(), newValue, new CacheItemPolicy
+                {
+                    //sliding expiration of 1 hr, if the same key isn't used in this 
+                    // timeframe it will be removed from the cache
+                    SlidingExpiration = new TimeSpan(1,0,0)
+                });
+                return (value ?? newValue).Value; // Lazy<T> handles the locking itself
+            }
+
             // Check cache
             _lock.EnterReadLock();
             TValue val;

--- a/src/NPoco/HashCodeCombiner.cs
+++ b/src/NPoco/HashCodeCombiner.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Globalization;
+
+namespace NPoco
+{
+    /// <summary>
+    /// Used to create a hash code from multiple objects.
+    /// </summary>
+    /// <remarks>
+    /// .Net has a class the same as this: System.Web.Util.HashCodeCombiner and of course it works for all sorts of things
+    /// which we've not included here as we just need a quick easy class for this in order to create a unique
+    /// hash of directories/files to see if they have changed.
+    /// </remarks>
+    internal class HashCodeCombiner
+    {
+        private long _combinedHash = 5381L;
+
+        internal void AddObject(object o)
+        {
+            AddInt(o.GetHashCode());
+        }
+
+        internal void AddInt(int i)
+        {
+            _combinedHash = ((_combinedHash << 5) + _combinedHash) ^ i;
+        }
+        
+        internal void AddCaseInsensitiveString(string s)
+        {
+            if (s != null)
+                AddInt((StringComparer.InvariantCultureIgnoreCase).GetHashCode(s));
+        }
+        
+        /// <summary>
+        /// Returns the hex code of the combined hash code
+        /// </summary>
+        /// <returns></returns>
+        internal string GetCombinedHashCode()
+        {
+            return _combinedHash.ToString("x", CultureInfo.InvariantCulture);
+        }
+
+    }
+}

--- a/src/NPoco/MappingFactory.cs
+++ b/src/NPoco/MappingFactory.cs
@@ -28,8 +28,16 @@ namespace NPoco
 
         public Delegate GetFactory(string sql, string connString, int firstColumn, int countColumns, IDataReader r, object instance)
         {
+            //Create a hashed key, we don't want to store so much string data in memory
+            var combiner = new HashCodeCombiner();
+            combiner.AddCaseInsensitiveString(sql);
+            combiner.AddCaseInsensitiveString(connString);
+            combiner.AddInt(firstColumn);
+            combiner.AddObject(instance != GetDefault(_pocoData.type));
+            combiner.AddObject(_pocoData.EmptyNestedObjectNull);
+
             // Check cache
-            var key = string.Format("{0}:{1}:{2}:{3}:{4}:{5}", sql, connString, firstColumn, countColumns, instance != GetDefault(_pocoData.type), _pocoData.EmptyNestedObjectNull);
+            var key = combiner.GetCombinedHashCode();
  
             Func<Delegate> createFactory = () =>
             {

--- a/src/NPoco/MappingFactory.cs
+++ b/src/NPoco/MappingFactory.cs
@@ -18,8 +18,10 @@ namespace NPoco
         static FieldInfo fldConverters = typeof(MappingFactory).GetField("m_Converters", BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
         static MethodInfo fnListGetItem = typeof(List<Func<object, object>>).GetProperty("Item").GetGetMethod();
         static MethodInfo fnInvoke = typeof(Func<object, object>).GetMethod("Invoke");
-        static Cache<Type, Type> _underlyingTypes = new Cache<Type, Type>();
-        Cache<string, Delegate> _pocoFactories = new Cache<string, Delegate>();
+        static Cache<Type, Type> _underlyingTypes = Cache<Type, Type>.CreateStaticCache();
+
+        //This will use a managed cache with items that expire
+        Cache<string, Delegate> _pocoFactories = Cache<string, Delegate>.CreateManagedCache();
 
         public MappingFactory(PocoData pocoData)
         {
@@ -28,6 +30,12 @@ namespace NPoco
 
         public Delegate GetFactory(string sql, string connString, int firstColumn, int countColumns, IDataReader r, object instance)
         {
+            //TODO: It would be nice to remove the irrelevant SQL parts - for a mapping operation anything after the SELECT clause isn't required. 
+            // This would ensure less duplicate entries that get cached, currently both of these queries would be cached even though they are
+            // returning the same structured data:
+            // SELECT * FROM MyTable ORDER BY MyColumn
+            // SELECT * FROM MyTable ORDER BY MyColumn DESC
+
             //Create a hashed key, we don't want to store so much string data in memory
             var combiner = new HashCodeCombiner();
             combiner.AddCaseInsensitiveString(sql);

--- a/src/NPoco/MultiPocoFactory.cs
+++ b/src/NPoco/MultiPocoFactory.cs
@@ -151,8 +151,8 @@ namespace NPoco
         }
 
         // Various cached stuff
-        static Cache<string, object> MultiPocoFactories = new Cache<string, object>();
-        static Cache<string, Delegate> AutoMappers = new Cache<string, Delegate>();
+        static Cache<string, object> MultiPocoFactories = Cache<string, object>.CreateStaticCache();
+        static Cache<string, Delegate> AutoMappers = Cache<string, Delegate>.CreateStaticCache();
 
         // Get (or create) the multi-poco factory for a query
         public static Func<IDataReader, Delegate, TRet> GetMultiPocoFactory<TRet>(Database database, Type[] types, string sql, string connectionString, IDataReader r)

--- a/src/NPoco/NPoco.csproj
+++ b/src/NPoco/NPoco.csproj
@@ -66,6 +66,7 @@
     <Compile Include="DatabaseTypes\SqlServerCEDatabaseType.cs" />
     <Compile Include="DatabaseTypes\SqlServerDatabaseType.cs" />
     <Compile Include="Expressions\FirebirdSqlExpression.cs" />
+    <Compile Include="HashCodeCombiner.cs" />
     <Compile Include="Linq\ComplexSqlBuilder.cs" />
     <Compile Include="Linq\DeleteQueryProvider.cs" />
     <Compile Include="Linq\ISimpleQueryProviderExpression.cs" />

--- a/src/NPoco/NPoco.csproj
+++ b/src/NPoco/NPoco.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/NPoco/PocoDataFactory.cs
+++ b/src/NPoco/PocoDataFactory.cs
@@ -6,7 +6,7 @@ namespace NPoco
     public class PocoDataFactory
     {
         private readonly IMapper _mapper;
-        static Cache<Type, PocoData> _pocoDatas = new Cache<Type, PocoData>();
+        static readonly Cache<Type, PocoData> _pocoDatas = Cache<Type, PocoData>.CreateStaticCache();
 
         public PocoDataFactory(IMapper mapper)
         {

--- a/src/NPoco/Properties/AssemblyInfo.cs
+++ b/src/NPoco/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
+
+[assembly: InternalsVisibleTo("NPoco.Tests")]


### PR DESCRIPTION
This PR is based off of the information in this blog post:

http://shazwazza.com/post/petapoco-can-cause-high-memory-usage-with-certain-queries/

I've created the PR for NPoco because it actually seems like it's active. I'll log a bug on PetaPoco too with a reference to this PR just for completeness.

This issue might not affect too many people but if developers don't know about this, memory usage can grow quite large. One of my projects used a Linq based approach to generating queries which didn't use parameters and just implemented them in strings... in a couple of days the memory usage for m_PocosData grew to over 150 mb. 

It's also worth noting that the memory can grow even without dynamically built queries, such as queries that perform an IN clause since the number of items in an array being passed to the IN clause is dynamic, meaning that each new count of parameters will also store a key and delegate in memory for the same query.

I found all of this out because the site was using far more memory than needed and it was clearly slowly growing. So i created a memory dump and had a look and all the extra mem was in m_PocosData.

This PR fixes a couple of the points in that blog post:

* Small hashed keys instead of giant strings
* Sliding expiration for the cached delegates

I've put a TODO in the code to remove the irrelevant parts of the query that is used to cache (as noted in the blog post).