### PR TITLE
Fix PocoDataFactory returning wrong pocodata

### DIFF
--- a/src/NPoco/PocoDataFactory.cs
+++ b/src/NPoco/PocoDataFactory.cs
@@ -6,7 +6,7 @@ namespace NPoco
     public class PocoDataFactory
     {
         private readonly IMapper _mapper;
-        static Cache<Type, PocoData> _pocoDatas = new Cache<Type, PocoData>();
+        private Cache<Type, PocoData> _pocoDatas = new Cache<Type, PocoData>();
 
         public PocoDataFactory(IMapper mapper)
         {


### PR DESCRIPTION
If two database factories have two mappings for the same poco, using
different table names for instance, then the PocoDataFactory should return
the correct PocoData for sed poco for each DatabaseFactory. The original
functionality would return the PocoData object for whichever mapping was
retrieved first, regardless of which DatabaseFactory requested the
PocoData.

- Make the poco data cache private
- Add test to prevent regression