### PR TITLE
Support for the AnsiString using the CustomColumnDbType attribute (VARCHAR)

### DIFF
--- a/src/NPoco/CustomColumnDbTypeAttribute.cs
+++ b/src/NPoco/CustomColumnDbTypeAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Data;
+
+namespace NPoco
+{
+    /// <summary>
+    /// Column Type Attribute.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class CustomColumnDbTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public DbType Type { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColumnTypeAttribute"/> class.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public CustomColumnDbTypeAttribute(DbType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
+++ b/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
@@ -53,6 +53,11 @@ namespace NPoco.DatabaseTypes
         {
             if (type == typeof (TimeSpan) || type == typeof(TimeSpan?))
                 return null;
+                
+            if (type == typeof (AnsiString))
+            {
+                return DbType.AnsiString;
+            }
             
             return base.LookupDbType(type, name);
         }

--- a/src/NPoco/Expressions/SqlExpression.cs
+++ b/src/NPoco/Expressions/SqlExpression.cs
@@ -1,13 +1,12 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Text;
 using System.Collections.ObjectModel;
+using System.Data;
+using System.Linq;
 using System.Linq.Expressions;
-using NPoco.Linq;
+using System.Reflection;
+using System.Text;
 
 namespace NPoco.Expressions
 {

--- a/src/NPoco/Expressions/SqlExpression.cs
+++ b/src/NPoco/Expressions/SqlExpression.cs
@@ -921,7 +921,15 @@ namespace NPoco.Expressions
             {
                 left = Visit(b.Left);
                 right = Visit(b.Right);
+                
+                var customAttribute = ((MemberExpression)b.Left).Member.GetCustomAttributes(typeof(CustomColumnDbTypeAttribute), false);
 
+                if (customAttribute.Any() &&
+                    ((CustomColumnDbTypeAttribute)customAttribute[0]).Type.Equals(DbType.AnsiString))
+                {
+                    right = new AnsiString((string) right);
+                }
+                
                 if (left as EnumMemberAccess != null && right as PartialSqlString == null)
                 {
                     var pc = ((EnumMemberAccess)left).PocoColumn;

--- a/src/NPoco/NPoco.csproj
+++ b/src/NPoco/NPoco.csproj
@@ -118,6 +118,7 @@
     <Compile Include="ReflectionUtils.cs" />
     <Compile Include="RelationExtensions.cs" />
     <Compile Include="PrimaryKeyAttribute.cs" />
+    <Compile Include="CustomColumnDbTypeAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultColumnAttribute.cs" />
     <Compile Include="Singleton.cs" />


### PR DESCRIPTION
Hi,
In order to convert the model type to the valid db type (VARCHAR instead of the NVARCHAR), the following solution should be used:

[CustomColumnDbType(DbType.AnsiString)]
public string ObjectKeyName { get; set; }

The using of the standard string c# type in case when the corresponding field in the db is VARCHAR slows down the queries. We've tested NPoco against this, and we found out that the performance is not acceptable.

Please do let me know if you have any suggestion regarding this implementation.

Best regards, 
Jovica