### PR TITLE
Sequence support for inserting data into MS SQL 2012

### DIFF
--- a/src/NPoco.Tests/App.config
+++ b/src/NPoco.Tests/App.config
@@ -11,8 +11,9 @@
           *     Oracle = 6 (Not supported yet)
           *     Postgres = 7 (not supported yet)
           *     Firebird = 8 
+          *     SQL 2012 = 9
           -->
-    <add key="TestDBType" value="2" />
+    <add key="TestDBType" value="9" />
   </appSettings>
 
   <system.data>

--- a/src/NPoco.Tests/Common/BaseDBDecoratedTest.cs
+++ b/src/NPoco.Tests/Common/BaseDBDecoratedTest.cs
@@ -43,6 +43,11 @@ namespace NPoco.Tests.Common
                     Database = new Database(TestDatabase.Connection, new FirebirdDatabaseType(), IsolationLevel.ReadUncommitted);
                     break;
 
+                case 9: // SQL 2012
+                    TestDatabase = new SQLLocalDatabase();
+                    Database = new Database(TestDatabase.Connection, new SqlServer2012DatabaseType(), IsolationLevel.ReadUncommitted); // Need read uncommitted for the transaction tests
+                    break;
+
                 default:
                     Assert.Fail("Unknown database platform specified");
                     return;

--- a/src/NPoco.Tests/Common/SQLLocalDatabase.cs
+++ b/src/NPoco.Tests/Common/SQLLocalDatabase.cs
@@ -104,6 +104,26 @@ namespace NPoco.Tests.Common
             cmd.ExecuteNonQuery();
 
             cmd.CommandText = @"
+                CREATE TABLE UsersForSequence(
+                    UserId int PRIMARY KEY NOT NULL, 
+                    Name nvarchar(200) NULL, 
+                    Age int NULL, 
+                    DateOfBirth datetime NULL, 
+                    Savings decimal(10,5) NULL,
+                    Is_Male tinyint,
+                    UniqueId uniqueidentifier NULL,
+                    TimeSpan time NULL,
+                    TestEnum varchar(10) NULL,
+                    HouseId int NULL,
+                    SupervisorId int NULL,
+                    Version rowversion,
+                    VersionInt int default(0) NOT NULL,
+                    YorN char NULL
+                );
+            ";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = @"
                 CREATE TABLE ExtraUserInfos(
                     ExtraUserInfoId int IDENTITY(1,1) PRIMARY KEY NOT NULL, 
                     UserId int NOT NULL, 
@@ -139,6 +159,9 @@ namespace NPoco.Tests.Common
             {
                 Console.WriteLine(row[2]);
             }
+
+            cmd.CommandText = @"CREATE SEQUENCE dbo.UsersForSequenceIds AS INT MINVALUE 1 NO MAXVALUE START WITH 1;";
+            cmd.ExecuteNonQuery();
 
             cmd.Dispose();
             conn.Close();

--- a/src/NPoco.Tests/Common/UserDecorated.cs
+++ b/src/NPoco.Tests/Common/UserDecorated.cs
@@ -3,6 +3,30 @@ using System.Collections.Generic;
 
 namespace NPoco.Tests.Common
 {
+    [TableName("UsersForSequence")]
+    [PrimaryKey("UserId", SequenceName = "UsersForSequenceIds")]
+    [ExplicitColumns]
+    public class UserDecoratedSequence
+    {
+        [Column("UserId")]
+        public int UserId { get; set; }
+
+        [Column("Name")]
+        public string Name { get; set; }
+
+        [Column("Age")]
+        public int Age { get; set; }
+
+        [Column("DateOfBirth")]
+        public DateTime DateOfBirth { get; set; }
+
+        [Column("Savings")]
+        public decimal Savings { get; set; }
+
+        [Column("is_male")]
+        public bool IsMale { get; set; }
+    }
+
     [TableName("Users")]
     [PrimaryKey("UserId")]
     [ExplicitColumns]

--- a/src/NPoco.Tests/DecoratedTests/CRUDTests/InsertTests.cs
+++ b/src/NPoco.Tests/DecoratedTests/CRUDTests/InsertTests.cs
@@ -8,6 +8,32 @@ namespace NPoco.Tests.DecoratedTests.CRUDTests
     public class InsertTests : BaseDBDecoratedTest
     {
         [Test]
+        public void InsertPrimaryKeySequenceSql()
+        {
+            const string dataName = "John Doe";
+            const int dataAge = 56;
+            const decimal dataSavings = (decimal)345.23;
+            var dataDateOfBirth = DateTime.Now;
+
+            var poco = new UserDecoratedSequence();
+            poco.Name = dataName;
+            poco.Age = dataAge;
+            poco.Savings = dataSavings;
+            poco.DateOfBirth = dataDateOfBirth;
+            Database.Insert(poco);
+
+            Assert.IsTrue(poco.UserId > 0, "POCO failed to insert.");
+
+            var verify = Database.SingleOrDefaultById<UserDecoratedSequence>(poco.UserId);
+            Assert.IsNotNull(verify);
+
+            Assert.AreEqual(poco.UserId, verify.UserId);
+            Assert.AreEqual(dataName, verify.Name);
+            Assert.AreEqual(dataAge, verify.Age);
+            Assert.AreEqual(dataSavings, verify.Savings);
+        }
+
+        [Test]
         public void InsertPrimaryKeyAutoIncrement()
         {
             const string dataName = "John Doe";

--- a/src/NPoco/DatabaseTypes/SqlServer2012DatabaseType.cs
+++ b/src/NPoco/DatabaseTypes/SqlServer2012DatabaseType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Linq;
 
 namespace NPoco.DatabaseTypes
@@ -12,6 +13,14 @@ namespace NPoco.DatabaseTypes
             var sqlPage = string.Format("{0}\nOFFSET @{1} ROWS FETCH NEXT @{2} ROWS ONLY", parts.sql, args.Length, args.Length + 1);
             args = args.Concat(new object[] { skip, take }).ToArray();
             return sqlPage;
+        }
+
+        public override string GetAutoIncrementExpression(TableInfo ti)
+        {
+            if (!string.IsNullOrEmpty(ti.SequenceName))
+                return string.Format("NEXT VALUE FOR {0}", ti.SequenceName);
+
+            return null;
         }
     }
 }

--- a/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
+++ b/src/NPoco/DatabaseTypes/SqlServerDatabaseType.cs
@@ -30,8 +30,13 @@ namespace NPoco.DatabaseTypes
             //var pocodata = PocoData.ForType(typeof(T), db.PocoDataFactory);
             //var sql = string.Format("SELECT * FROM {0} WHERE {1} = SCOPE_IDENTITY()", EscapeTableName(pocodata.TableInfo.TableName), EscapeSqlIdentifier(primaryKeyName));
             //return db.SingleInto(poco, ";" + cmd.CommandText + ";" + sql, args);
-            cmd.CommandText += ";SELECT SCOPE_IDENTITY();";
+            //cmd.CommandText += ";SELECT SCOPE_IDENTITY();";
             return db.ExecuteScalarHelper(cmd);
+        }
+
+        public override string GetInsertOutputClause(string primaryKeyName)
+        {
+            return " OUTPUT INSERTED." + primaryKeyName;
         }
 
         public override string GetExistsSql()


### PR DESCRIPTION
I've added some minimal changes to support sequences in MS SQL, as it is supported by Oracle..
The biggest change is to remove SELECT SCOPE_IDENTITY(); and use OUTPUT INSERTED instead.
What you think about it?