### PR TITLE
InsertAsync<T>(T poco) is no longer overridable in 3.1

### DIFF
--- a/src/NPoco/AsyncDatabase.cs
+++ b/src/NPoco/AsyncDatabase.cs
@@ -36,7 +36,7 @@ namespace NPoco
         public Task<object> InsertAsync<T>(T poco)
         {
             var pd = PocoDataFactory.ForType(poco.GetType());
-            return InsertAsyncImp(pd, pd.TableInfo.TableName, pd.TableInfo.PrimaryKey, pd.TableInfo.AutoIncrement, poco);
+            return InsertAsync(pd.TableInfo.TableName, pd.TableInfo.PrimaryKey, pd.TableInfo.AutoIncrement, poco);
         }
 
         /// <summary>


### PR DESCRIPTION
AsyncDatabase.cs on line 39 used to call InsertAsync, but now calls InsertAsyncImp which means you can no longer use the overridable definition of InsertAsync to intercept calls.

This was changed in commit [176d9ef](https://github.com/schotime/NPoco/commit/176d9ef6faff96c55b56738cb34e265f9cdf6921). 

PocoDataFactory is now getting called twice. Not sure how expensive this call is, but might need to modify slightly if expensive.