### PR TITLE
Add parameterless overload to FetchAsync<T>

### DIFF
--- a/src/NPoco/AsyncDatabase.cs
+++ b/src/NPoco/AsyncDatabase.cs
@@ -187,6 +187,11 @@ namespace NPoco
             return (await QueryAsync<T>(sql, args).ConfigureAwait(false)).ToList();
         }
 
+        public Task<List<T>> FetchAsync<T>()
+        {
+            return FetchAsync<T>("");
+        }
+
         public async Task<List<T>> FetchAsync<T>(Sql sql)
         {
             return (await QueryAsync<T>(sql).ConfigureAwait(false)).ToList();


### PR DESCRIPTION
The [non async](https://github.com/schotime/NPoco/blob/d5dae4e96354f928476c595d9726fd810fda19e0/src/NPoco/Database.cs#L811) `Fetch<T>` method has it, so why not do the same for `FetchAsync<T>`
