### PR TITLE
Add runtime exception for misleading PrimaryKey config

### DIFF
--- a/src/NPoco/PrimaryKeyAttribute.cs
+++ b/src/NPoco/PrimaryKeyAttribute.cs
@@ -8,12 +8,27 @@ namespace NPoco
         public PrimaryKeyAttribute(string primaryKey)
         {
             Value = primaryKey;
-            AutoIncrement = true;
+            _autoIncrement = true;
         }
 
         public string Value { get; private set; }
         public string SequenceName { get; set; }
-        public bool AutoIncrement { get; set; }
+        
+        
+        private bool _autoIncrement;
+
+        public bool AutoIncrement
+        {
+            get { return _autoIncrement; }
+            set{
+                _autoIncrement = value;
+                if (value && Value.Contains(","))
+                {
+                    throw new InvalidOperationException("Cannot set AutoIncrement to true when the primary key is a Composite Key");
+                }
+            }
+        }
+        
         public bool UseOutputClause { get; set; }
     }
 }


### PR DESCRIPTION
When the PrimaryKey attribute is used to set a composite key, the AutoIncrement option is forced to false. This commit ensures that developers get a helpful run-time error as opposed to being forced to scratch their heads in wonderment.
