### PR TITLE
Bugfix - underscore character in StartsWith, EndsWith, Contains interpeted as wildcard character

### DIFF
--- a/src/NPoco/Expressions/SqlExpression.cs
+++ b/src/NPoco/Expressions/SqlExpression.cs
@@ -98,6 +98,7 @@ namespace NPoco.Expressions
         }
 
         private string sep = string.Empty;
+        private char EscapeChar = '\\';
         private PocoData _pocoData;
         private readonly IDatabase _database;
         private readonly DatabaseType _databaseType;
@@ -1603,13 +1604,13 @@ namespace NPoco.Expressions
                     statement = string.Format("lower({0})", expression);
                     break;
                 case "StartsWith":
-                    statement = string.Format("upper({0}) like {1}", expression, CreateParam(args[0].ToString().ToUpper() + "%"));
+                    statement = CreateLikeStatement(expression, CreateParam(EscapeParam(args[0]) + "%"));
                     break;
                 case "EndsWith":
-                    statement = string.Format("upper({0}) like {1}", expression, CreateParam("%" + args[0].ToString().ToUpper()));
+                    statement = CreateLikeStatement(expression, CreateParam("%" + EscapeParam(args[0])));
                     break;
                 case "Contains":
-                    statement = string.Format("upper({0}) like {1}", expression, CreateParam("%" + args[0].ToString().ToUpper() + "%"));
+                    statement = CreateLikeStatement(expression, CreateParam("%" + EscapeParam(args[0]) + "%"));
                     break;
                 case "Substring":
                     var startIndex = Int32.Parse(args[0].ToString()) + 1;
@@ -1627,6 +1628,19 @@ namespace NPoco.Expressions
             }
 
             return new PartialSqlString(statement);
+        }
+
+        protected virtual string CreateLikeStatement(PartialSqlString expression, string param)
+        {
+            return string.Format("upper({0}) like {1} escape '{2}'", expression, param, EscapeChar);
+        }
+
+        protected virtual string EscapeParam(object par)
+        {
+            var param = par.ToString().ToUpper();
+            param = param.Replace(EscapeChar.ToString(), EscapeChar.ToString() + EscapeChar)
+                .Replace("_", EscapeChar + "_");
+            return param;
         }
 
         // Easy to override

--- a/test/NPoco.Tests/Common/BaseDBFuentTest.cs
+++ b/test/NPoco.Tests/Common/BaseDBFuentTest.cs
@@ -137,6 +137,12 @@ namespace NPoco.Tests.Common
                 InMemoryHouses.Add(house);
             }
 
+            Database.Insert(new House
+                {
+                    Address = "_ Road\\Street, Suburb"
+                }
+            );
+
             for (var i = 0; i < 15; i++)
             {
                 var user = new User

--- a/test/NPoco.Tests/FluentTests/QueryTests/QueryProviderTests.cs
+++ b/test/NPoco.Tests/FluentTests/QueryTests/QueryProviderTests.cs
@@ -523,6 +523,20 @@ namespace NPoco.Tests.FluentTests.QueryTests
             Assert.AreEqual(1, user.UserId);
         }
 
+        [Test]
+        public void QueryWithWhereContainsStartsWithUnderscore()
+        {
+            var houses = Database.Query<House>().Where(o => o.Address.StartsWith("_")).ToList();
+            Assert.AreEqual(1, houses.Count);
+        }
+
+        [Test]
+        public void QueryWithWhereContainsStartsWithEscapeChar()
+        {
+            var houses = Database.Query<House>().Where(o => o.Address.Contains("\\")).ToList();
+            Assert.AreEqual(1, houses.Count);
+        }
+
         //[Test]
         //public void QueryWithInheritedTypesAliasCorrectlyWithJoin()
         //{


### PR DESCRIPTION
This is the bugfix.
Underscore character in Query contains Where with StartsWith, EndsWith or Contains interpreted as wildcard character.
I tested this with Oracle and MS SQL.
Have a nice day!