### PR TITLE
Fix fastJSON deserialization into dicts with interface type values [#354]

### DIFF
--- a/src/NPoco/fastJSON/JSON.cs
+++ b/src/NPoco/fastJSON/JSON.cs
@@ -412,6 +412,11 @@ namespace NPoco.fastJSON
 
         private object ChangeType(object value, Type conversionType)
         {
+            if (conversionType.IsAssignableFrom(value.GetType()))
+            {
+                return value;
+            }
+
             if (conversionType == typeof(int))
                 return (int)((long)value);
 


### PR DESCRIPTION
Eliminated the type conversion in the case it is not actually needed. I’m currently on my first-ever C# project so it is possible I’m in way over my head dealing with reflection.