### PR TITLE
Fixed exception when assigning value to a nullable primary key

### DIFF
--- a/src/NPoco/PocoColumn.cs
+++ b/src/NPoco/PocoColumn.cs
@@ -73,7 +73,11 @@ namespace NPoco
             return target;
         }
 
-        public virtual object ChangeType(object val) { return Convert.ChangeType(val, MemberInfoData.MemberType); }
+        public virtual object ChangeType(object val)
+        {
+            var type = Nullable.GetUnderlyingType(MemberInfoData.MemberType) ?? MemberInfoData.MemberType;
+            return Convert.ChangeType(val, type);
+        }
 
         public object GetColumnValue(PocoData pd, object target, Func<PocoColumn, object, object> callback = null)
         {


### PR DESCRIPTION
In the case of Oracle, if your poco is using a nullable primary key, it will fail because Convert.ChangeType() cannot convert the value to a nullable.  This gets the base type if the column is a nullable.
