### PR TITLE
User friendly validation for PageImp

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -1197,6 +1197,11 @@ namespace NPoco
         // Actual implementation of the multi-poco paging
         protected TRet PageImp<T, TRet>(long page, long itemsPerPage, string sql, object[] args, Func<Page<T>, Sql, TRet> executeQueryFunc)
         {
+            if (page <= 0 || itemsPerPage <= 0)
+            {
+                throw new ArgumentException("Parameter page and itemsPerPage must be greater then zero.");
+            }
+
             string sqlCount, sqlPage;
 
             long offset = (page - 1) * itemsPerPage;


### PR DESCRIPTION
Add a user-friendly validation for page and itemsPerPage parameters avoiding strange behavior like DivideByZeroException, to make it easy-tracking for some coding mistake.