### PR TITLE
Subquery and aggreagation supports

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -38,7 +38,7 @@ namespace NPoco
         public Database(DbConnection connection, DatabaseType dbType)
             : this(connection, dbType, null, DefaultEnableAutoSelect)
         { }
-        
+
         public Database(DbConnection connection, DatabaseType dbType, IsolationLevel? isolationLevel)
             : this(connection, dbType, isolationLevel, DefaultEnableAutoSelect)
         { }
@@ -97,7 +97,7 @@ namespace NPoco
         { }
 
         public Database(string connectionString, DatabaseType dbType, IsolationLevel? isolationLevel)
-            : this(connectionString, dbType, isolationLevel,  DefaultEnableAutoSelect)
+            : this(connectionString, dbType, isolationLevel, DefaultEnableAutoSelect)
         { }
 
         public Database(string connectionString, DatabaseType dbType, IsolationLevel? isolationLevel, bool enableAutoSelect)
@@ -141,10 +141,10 @@ namespace NPoco
         { }
 
         public Database(string connectionStringName, bool enableAutoSelect)
-            : this(connectionStringName, (IsolationLevel?) null, enableAutoSelect)
+            : this(connectionStringName, (IsolationLevel?)null, enableAutoSelect)
         { }
 
-        public Database(string connectionStringName, IsolationLevel? isolationLevel,  bool enableAutoSelect)
+        public Database(string connectionStringName, IsolationLevel? isolationLevel, bool enableAutoSelect)
         {
             EnableAutoSelect = enableAutoSelect;
             KeepConnectionAlive = false;
@@ -491,7 +491,7 @@ namespace NPoco
             p.ParameterName = string.Format("{0}{1}", _paramPrefix, cmd.Parameters.Count);
 
             SetParameterValue(p, value);
-            
+
             cmd.Parameters.Add(p);
         }
 
@@ -589,7 +589,7 @@ namespace NPoco
         {
             return CreateCommand(connection, CommandType.Text, sql, args);
         }
-        
+
         public virtual DbCommand CreateCommand(DbConnection connection, CommandType commandType, string sql, params object[] args)
         {
             if (commandType == CommandType.StoredProcedure)
@@ -605,7 +605,7 @@ namespace NPoco
             // Create the command and add parameters
             DbCommand cmd = connection.CreateCommand();
             cmd.Connection = connection;
-            cmd.CommandText = sql;            
+            cmd.CommandText = sql;
             cmd.Transaction = _transaction;
 
             foreach (var item in args)
@@ -729,7 +729,7 @@ namespace NPoco
             var result = OnDeleting(deleteContext);
             return result && Interceptors.OfType<IDataInterceptor>().All(x => x.OnDeleting(this, deleteContext));
         }
-        
+
         public DbCommand CreateStoredProcedureCommand(DbConnection connection, string name, params object[] args)
         {
             DbCommand cmd = connection.CreateCommand();
@@ -748,13 +748,13 @@ namespace NPoco
                 else
                 {
                     var props = args[0].GetType().GetProperties().Select(x => new { x.Name, Value = x.GetValue(args[0], null) }).ToList();
-                    foreach(var item in props)
+                    foreach (var item in props)
                     {
                         DbParameter param = cmd.CreateParameter();
                         param.ParameterName = item.Name;
 
                         SetParameterValue(param, item.Value);
-                        
+
                         cmd.Parameters.Add(param);
                     }
                 }
@@ -808,7 +808,7 @@ namespace NPoco
         {
             return ExecuteScalar<T>(new Sql(sql, args));
         }
-        
+
         public T ExecuteScalar<T>(Sql Sql)
         {
             return ExecuteScalar<T>(Sql.SQL, CommandType.Text, Sql.Arguments);
@@ -1061,6 +1061,11 @@ namespace NPoco
             return new QueryProvider<T>(this);
         }
 
+        public SubQueryProvider<T> FromSubQuery<T>(IQueryProvider<T> subQuery)
+        {
+            return new SubQueryProvider<T>(this, subQuery);
+        }
+
         private IEnumerable<T> Query<T>(T instance, Sql Sql)
         {
             return QueryImp(instance, null, null, Sql);
@@ -1120,7 +1125,7 @@ namespace NPoco
             var sql = Sql.SQL;
             var args = Sql.Arguments;
 
-            if (EnableAutoSelect) sql = AutoSelectHelper.AddSelectClause(this, typeof (T), sql);
+            if (EnableAutoSelect) sql = AutoSelectHelper.AddSelectClause(this, typeof(T), sql);
 
             try
             {
@@ -1189,7 +1194,7 @@ namespace NPoco
         {
             return PageImp<T, Page<T>>(page, itemsPerPage, sql, args, (paged, thesql) =>
             {
-                paged.Items =  Query<T>(thesql).ToList();
+                paged.Items = Query<T>(thesql).ToList();
                 return paged;
             });
         }
@@ -1274,16 +1279,16 @@ namespace NPoco
                                     switch (typeIndex)
                                     {
                                         case 1:
-                                            list1.Add((T1) factory.Map(r, default(T1)));
+                                            list1.Add((T1)factory.Map(r, default(T1)));
                                             break;
                                         case 2:
-                                            list2.Add((T2) factory.Map(r, default(T2)));
+                                            list2.Add((T2)factory.Map(r, default(T2)));
                                             break;
                                         case 3:
-                                            list3.Add((T3) factory.Map(r, default(T3)));
+                                            list3.Add((T3)factory.Map(r, default(T3)));
                                             break;
                                         case 4:
-                                            list4.Add((T4) factory.Map(r, default(T4)));
+                                            list4.Add((T4)factory.Map(r, default(T4)));
                                             break;
                                     }
                                 }
@@ -1300,11 +1305,11 @@ namespace NPoco
                         switch (types.Length)
                         {
                             case 2:
-                                return ((Func<List<T1>, List<T2>, TRet>) cb)(list1, list2);
+                                return ((Func<List<T1>, List<T2>, TRet>)cb)(list1, list2);
                             case 3:
-                                return ((Func<List<T1>, List<T2>, List<T3>, TRet>) cb)(list1, list2, list3);
+                                return ((Func<List<T1>, List<T2>, List<T3>, TRet>)cb)(list1, list2, list3);
                             case 4:
-                                return ((Func<List<T1>, List<T2>, List<T3>, List<T4>, TRet>) cb)(list1, list2, list3, list4);
+                                return ((Func<List<T1>, List<T2>, List<T3>, List<T4>, TRet>)cb)(list1, list2, list3, list4);
                         }
 
                         return default(TRet);
@@ -1328,7 +1333,7 @@ namespace NPoco
         public bool Exists<T>(object primaryKey)
         {
             var index = 0;
-            var pd = PocoDataFactory.ForType(typeof (T));
+            var pd = PocoDataFactory.ForType(typeof(T));
             var primaryKeyValuePairs = GetPrimaryKeyValues(pd, pd.TableInfo.PrimaryKey, primaryKey, false);
             return ExecuteScalar<int>(string.Format(DatabaseType.GetExistsSql(), DatabaseType.EscapeTableName(pd.TableInfo.TableName), BuildPrimaryKeySql(primaryKeyValuePairs, ref index)), primaryKeyValuePairs.Select(x => x.Value).ToArray()) > 0;
         }
@@ -1348,7 +1353,7 @@ namespace NPoco
         private Sql GenerateSingleByIdSql<T>(object primaryKey)
         {
             var index = 0;
-            var pd = PocoDataFactory.ForType(typeof (T));
+            var pd = PocoDataFactory.ForType(typeof(T));
             var primaryKeyValuePairs = GetPrimaryKeyValues(pd, pd.TableInfo.PrimaryKey, primaryKey, primaryKey is T);
             var sql = AutoSelectHelper.AddSelectClause(this, typeof(T), string.Format("WHERE {0}", BuildPrimaryKeySql(primaryKeyValuePairs, ref index)));
             var args = primaryKeyValuePairs.Select(x => x.Value).ToArray();
@@ -1495,7 +1500,7 @@ namespace NPoco
 
                 foreach (var batchedPocos in pocos.Chunkify(options.BatchSize))
                 {
-                    var preparedInserts = batchedPocos.Select(x => InsertStatements.PrepareInsertSql(this, pd, pd.TableInfo.TableName, pd.TableInfo.PrimaryKey,pd.TableInfo.AutoIncrement, x)).ToArray();
+                    var preparedInserts = batchedPocos.Select(x => InsertStatements.PrepareInsertSql(this, pd, pd.TableInfo.TableName, pd.TableInfo.PrimaryKey, pd.TableInfo.AutoIncrement, x)).ToArray();
 
                     var sql = new Sql();
                     foreach (var preparedInsertSql in preparedInserts)
@@ -1571,9 +1576,9 @@ namespace NPoco
             {
                 // Don't update the primary key, but grab the value if we don't have it
                 if (primaryKeyValuePairs.ContainsKey(pocoColumn.ColumnName))
-                { 
+                {
                     if (primaryKeyValue == null)
-                         primaryKeyValuePairs[pocoColumn.ColumnName] = this.ProcessMapper(pocoColumn, pocoColumn.GetValue(poco));
+                        primaryKeyValuePairs[pocoColumn.ColumnName] = this.ProcessMapper(pocoColumn, pocoColumn.GetValue(poco));
                     continue;
                 }
 
@@ -1720,8 +1725,8 @@ namespace NPoco
         {
             var expression = DatabaseType.ExpressionVisitor<T>(this, PocoDataFactory.ForType(typeof(T)));
             expression = expression.Select(fields);
-            var columnNames = ((ISqlExpression) expression).SelectMembers.Select(x => x.PocoColumn.ColumnName);
-            var otherNames = ((ISqlExpression) expression).GeneralMembers.Select(x => x.PocoColumn.ColumnName);
+            var columnNames = ((ISqlExpression)expression).SelectMembers.Select(x => x.PocoColumn.ColumnName);
+            var otherNames = ((ISqlExpression)expression).GeneralMembers.Select(x => x.PocoColumn.ColumnName);
             return Update(poco, columnNames.Union(otherNames));
         }
 
@@ -2022,7 +2027,7 @@ namespace NPoco
             var converter = database.Mappers.Find(x => x.GetToDbConverter(pc.ColumnType, pc.MemberInfoData.MemberInfo));
             return converter != null ? converter(value) : ProcessDefaultMappings(database, pc, value);
         }
-        
+
         internal static object ProcessDefaultMappings(IDatabase database, PocoColumn pocoColumn, object value)
         {
             if (pocoColumn.SerializedColumn)

--- a/src/NPoco/IDatabase.cs
+++ b/src/NPoco/IDatabase.cs
@@ -73,7 +73,7 @@ namespace NPoco
         /// Insert POCO into the table by convention or configuration
         /// </summary>   
         object Insert<T>(T poco);
-              
+
 #if !NET35 && !NET40
         /// <summary>
         /// Insert POCO into the table by convention or configuration

--- a/src/NPoco/IDatabaseQuery.cs
+++ b/src/NPoco/IDatabaseQuery.cs
@@ -16,22 +16,22 @@ namespace NPoco
         /// Opens the DbConnection manually
         /// </summary>
         IDatabase OpenSharedConnection();
-        
+
         /// <summary>
         /// Closes the DBConnection manually
         /// </summary>
         void CloseSharedConnection();
-        
+
         /// <summary>
         /// Builds a paged query from a non-paged query
         /// </summary>
         void BuildPageQueries<T>(long skip, long take, string sql, ref object[] args, out string sqlCount, out string sqlPage);
-        
+
         /// <summary>
         /// Executes the provided sql and parameters
         /// </summary>
         int Execute(string sql, params object[] args);
-        
+
         /// <summary>
         /// Executes the provided sql and parameters
         /// </summary>
@@ -46,7 +46,7 @@ namespace NPoco
         /// Executes the provided sql and parameters and casts the result to T
         /// </summary>
         T ExecuteScalar<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Executes the provided sql and parameters and casts the result to T
         /// </summary>
@@ -61,18 +61,18 @@ namespace NPoco
         /// Non generic Fetch which returns a list of objects of the given type provided
         /// </summary>
         List<object> Fetch(Type type, string sql, params object[] args);
-        
+
         /// <summary>
         /// Non generic Fetch which returns a list of objects of the given type provided
         /// </summary>
         List<object> Fetch(Type type, Sql Sql);
-        
+
         /// <summary>
         /// Non generic Query which returns a list of objects of the given type provided. 
         /// Caution: This query will only be executed once you start iterating the result
         /// </summary>
         IEnumerable<object> Query(Type type, string sql, params object[] args);
-        
+
         /// <summary>
         /// Non generic Query which returns a list of objects of the given type provided. 
         /// Caution: This query will only be executed once you start iterating the result
@@ -84,29 +84,29 @@ namespace NPoco
         /// Caution: This will retrieve ALL objects in the table
         /// </summary>
         List<T> Fetch<T>();
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// </summary>
         List<T> Fetch<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified
         /// </summary>
         List<T> Fetch<T>(Sql sql);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// The sql provided will be converted so that only the results for the page and itemsPerPage values specified will be returned.
         /// </summary>
         List<T> Fetch<T>(long page, long itemsPerPage, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// The sql provided will be converted so that only the results for the page and itemsPerPage values specified will be returned.
         /// </summary>
         List<T> Fetch<T>(long page, long itemsPerPage, Sql sql);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// The sql provided will be converted so that only the results for the page and itemsPerPage specified will be returned.
@@ -114,7 +114,7 @@ namespace NPoco
         /// Note: This will perform two queries. One for the paged results and one for the count of all results.
         /// </summary>
         Page<T> Page<T>(long page, long itemsPerPage, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// The sql provided will be converted so that only the results for the page and itemsPerPage specified will be returned.
@@ -128,7 +128,7 @@ namespace NPoco
         /// The sql provided will be converted so that only the results for the skip and take values specified will be returned.
         /// </summary>
         List<T> SkipTake<T>(long skip, long take, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// The sql provided will be converted so that only the results for the skip and take values specified will be returned.
@@ -141,21 +141,21 @@ namespace NPoco
         /// eg. select one.*, many.* from one inner join many on one.id = many.oneid
         /// </summary>
         List<T> FetchOneToMany<T>(Expression<Func<T, IList>> many, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T using the sql provided, but also retrieve the many property's data using the sql provided.
         /// The one columns should come first then the many columns. 
         /// eg. select one.*, many.* from one inner join many on one.id = many.oneid
         /// </summary>
         List<T> FetchOneToMany<T>(Expression<Func<T, IList>> many, Sql sql);
-        
+
         /// <summary>
         /// Fetch objects of type T using the sql provided, but also retrieve the many property's data using the sql provided.
         /// The one columns should come first then the many columns. 
         /// eg. select one.*, many.* from one inner join many on one.id = many.oneid
         /// </summary>
         List<T> FetchOneToMany<T>(Expression<Func<T, IList>> many, Func<T, object> idFunc, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T using the sql provided, but also retrieve the many property's data using the sql provided.
         /// The one columns should come first then the many columns. 
@@ -168,43 +168,46 @@ namespace NPoco
         /// Caution: This query will only be executed once you start iterating the result
         /// </summary>
         IEnumerable<T> Query<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch objects of type T from the database using the sql and parameters specified. 
         /// Caution: This query will only be executed once you start iterating the result
         /// </summary>
         IEnumerable<T> Query<T>(Sql sql);
-        
+
+        //IQueryProvider<T> Query<T,K>(IQueryProvider<K> subQuery);
+        SubQueryProvider<T> FromSubQuery<T>(IQueryProvider<T> subQuery);
+
         /// <summary>
         /// Entry point for LINQ queries
         /// </summary>
         IQueryProviderWithIncludes<T> Query<T>();
-        
+
         /// <summary>
         /// Get an object of type T by primary key value
         /// </summary>
         T SingleById<T>(object primaryKey);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the sql and parameters specified
         /// </summary>
         T Single<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the sql and parameters specified into the T instance provided
         /// </summary>
         T SingleInto<T>(T instance, string sql, params object[] args);
-        
+
         /// <summary>
         /// Get an object of type T by primary key value where the row may not be there
         /// </summary>
         T SingleOrDefaultById<T>(object primaryKey);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the sql and parameters specified
         /// </summary>
         T SingleOrDefault<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the sql and parameters specified into the T instance provided
         /// </summary>
@@ -214,17 +217,17 @@ namespace NPoco
         /// Fetch the first row of type T using the sql and parameters specified
         /// </summary>
         T First<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the sql and parameters specified into the T instance provided
         /// </summary>
         T FirstInto<T>(T instance, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the sql and parameters specified
         /// </summary>
         T FirstOrDefault<T>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the sql and parameters specified into the T instance provided
         /// </summary>
@@ -234,37 +237,37 @@ namespace NPoco
         /// Fetch the only row of type T using the Sql specified
         /// </summary>
         T Single<T>(Sql sql);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the Sql specified into the T instance provided
         /// </summary>
         T SingleInto<T>(T instance, Sql sql);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the Sql specified
         /// </summary>
         T SingleOrDefault<T>(Sql sql);
-        
+
         /// <summary>
         /// Fetch the only row of type T using the Sql specified
         /// </summary>
         T SingleOrDefaultInto<T>(T instance, Sql sql);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the Sql specified
         /// </summary>
         T First<T>(Sql sql);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the Sql specified into the T instance provided
         /// </summary>
         T FirstInto<T>(T instance, Sql sql);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the Sql specified
         /// </summary>
         T FirstOrDefault<T>(Sql sql);
-        
+
         /// <summary>
         /// Fetch the first row of type T using the Sql specified
         /// </summary>
@@ -274,17 +277,17 @@ namespace NPoco
         /// Fetches the first two columns into a dictionary using the first value as the key and the second as the value
         /// </summary>
         Dictionary<TKey, TValue> Dictionary<TKey, TValue>(Sql Sql);
-        
+
         /// <summary>
         /// Fetches the first two columns into a dictionary using the first value as the key and the second as the value
         /// </summary>
         Dictionary<TKey, TValue> Dictionary<TKey, TValue>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Checks if the POCO of type T exists by using the primary key value
         /// </summary>
         bool Exists<T>(object primaryKey);
-        
+
         /// <summary>
         /// Specifies the command timeout to be used for the very next command
         /// </summary>
@@ -295,31 +298,31 @@ namespace NPoco
         /// In this method you must provide how you will take the results and combine them
         /// </summary>
         TRet FetchMultiple<T1, T2, TRet>(Func<List<T1>, List<T2>, TRet> cb, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one object.
         /// In this method you must provide how you will take the results and combine them
         /// </summary>
         TRet FetchMultiple<T1, T2, T3, TRet>(Func<List<T1>, List<T2>, List<T3>, TRet> cb, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one object.
         /// In this method you must provide how you will take the results and combine them
         /// </summary>
         TRet FetchMultiple<T1, T2, T3, T4, TRet>(Func<List<T1>, List<T2>, List<T3>, List<T4>, TRet> cb, string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one object.
         /// In this method you must provide how you will take the results and combine them
         /// </summary>
         TRet FetchMultiple<T1, T2, TRet>(Func<List<T1>, List<T2>, TRet> cb, Sql sql);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one object.
         /// In this method you must provide how you will take the results and combine them
         /// </summary>
         TRet FetchMultiple<T1, T2, T3, TRet>(Func<List<T1>, List<T2>, List<T3>, TRet> cb, Sql sql);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one object.
         /// In this method you must provide how you will take the results and combine them
@@ -330,27 +333,27 @@ namespace NPoco
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>
         Tuple<List<T1>, List<T2>> FetchMultiple<T1, T2>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>
         Tuple<List<T1>, List<T2>, List<T3>> FetchMultiple<T1, T2, T3>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>
         Tuple<List<T1>, List<T2>, List<T3>, List<T4>> FetchMultiple<T1, T2, T3, T4>(string sql, params object[] args);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>
         Tuple<List<T1>, List<T2>> FetchMultiple<T1, T2>(Sql sql);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>
         Tuple<List<T1>, List<T2>, List<T3>> FetchMultiple<T1, T2, T3>(Sql sql);
-        
+
         /// <summary>
         /// Fetches multiple result sets into the one Tuple.
         /// </summary>

--- a/src/NPoco/Linq/SimpleQueryProvider.cs
+++ b/src/NPoco/Linq/SimpleQueryProvider.cs
@@ -32,6 +32,7 @@ namespace NPoco.Linq
         List<T2> ProjectTo<T2>(Expression<Func<T, T2>> projectionExpression);
         List<T2> Distinct<T2>(Expression<Func<T, T2>> projectionExpression);
         List<T> Distinct();
+        List<T2> GroupByAndProject<T2>(Expression<Func<T, T2>> column);
 #if !NET35 && !NET40
         System.Threading.Tasks.Task<List<T>> ToListAsync();
         System.Threading.Tasks.Task<T[]> ToArrayAsync();
@@ -51,6 +52,7 @@ namespace NPoco.Linq
 
     public interface IQueryProvider<T> : IQueryResultProvider<T>
     {
+        Sql BuildSql();
         IQueryProvider<T> Where(Expression<Func<T, bool>> whereExpression);
         IQueryProvider<T> Where(string sql, params object[] args);
         IQueryProvider<T> Where(Sql sql);
@@ -62,6 +64,12 @@ namespace NPoco.Linq
         IQueryProvider<T> Limit(int rows);
         IQueryProvider<T> Limit(int skip, int rows);
         IQueryProvider<T> From(QueryBuilder<T> builder);
+        IQueryProvider<T> GroupBy(Expression<Func<T, object>> column);
+        IQueryProvider<T> Select(Expression<Func<T, object>> column, string alias = null);
+        IQueryProvider<T> Sum(Expression<Func<T, object>> column, string alias = null);
+        IQueryProvider<T> Avg(Expression<Func<T, object>> column, string alias = null);
+        IQueryProvider<T> CountExp(Expression<Func<T, object>> column, string alias = null);
+        List<K> Execute<K>();
     }
 
     public interface IQueryProviderWithIncludes<T> : IQueryProvider<T>
@@ -72,19 +80,49 @@ namespace NPoco.Linq
         IQueryProviderWithIncludes<T> UsingAlias(string empty);
     }
 
+    public class SubQueryProvider<T> : QueryProvider<T>
+    {
+        private IQueryProvider<T> _subQuery;
+
+        public IQueryProvider<T> SubQuery { get { return _subQuery; } }
+
+        public SubQueryProvider(Database database, IQueryProvider<T> subQuery) : base(database, null, subQuery.BuildSql().SQL)
+        {
+            _subQuery = subQuery;
+            _sqlExpression.Context.AddParams(_subQuery.BuildSql().Arguments);
+        }
+
+        public override Sql BuildSql()
+        {
+            Sql sql;
+            if (_joinSqlExpressions.Any())
+                sql = _buildComplexSql.BuildJoin(_database, _sqlExpression, _joinSqlExpressions.Values.ToList(), null, false, false);
+            else
+                sql = new Sql(true, _sqlExpression.Context.ToSelectStatement(), _sqlExpression.Context.Params);
+            return sql;
+        }
+    }
+
     public class QueryProvider<T> : IQueryProviderWithIncludes<T>, ISimpleQueryProviderExpression<T>
     {
-        private readonly Database _database;
-        private SqlExpression<T> _sqlExpression;
-        private Dictionary<string, JoinData> _joinSqlExpressions = new Dictionary<string, JoinData>();
-        private readonly ComplexSqlBuilder<T> _buildComplexSql;
-        private Expression<Func<T, IList>> _listExpression = null;
-        private PocoData _pocoData;
+        protected readonly Database _database;
+        protected SqlExpression<T> _sqlExpression;
+        protected Dictionary<string, JoinData> _joinSqlExpressions = new Dictionary<string, JoinData>();
+        protected readonly ComplexSqlBuilder<T> _buildComplexSql;
+        protected Expression<Func<T, IList>> _listExpression = null;
+        protected PocoData _pocoData;
 
-        public QueryProvider(Database database, Expression<Func<T, bool>> whereExpression)
+
+        public QueryProvider(Database database, Expression<Func<T, bool>> whereExpression, string subQuery = null)
         {
             _database = database;
-            _pocoData = database.PocoDataFactory.ForType(typeof (T));
+            _pocoData = database.PocoDataFactory.ForType(typeof(T));
+            if (subQuery != null)
+            {
+                _pocoData.TableInfo.TableName = subQuery;
+                _pocoData.TableInfo.IsInlineView = true;
+            }
+
             _sqlExpression = database.DatabaseType.ExpressionVisitor<T>(database, _pocoData, true);
             _buildComplexSql = new ComplexSqlBuilder<T>(database, _pocoData, _sqlExpression, _joinSqlExpressions);
             _sqlExpression = _sqlExpression.Where(whereExpression);
@@ -310,7 +348,7 @@ namespace NPoco.Linq
             return ToEnumerable().ToArray();
         }
 
-        public List<T> ToList()
+        public virtual List<T> ToList()
         {
             return ToEnumerable().ToList();
         }
@@ -334,12 +372,12 @@ namespace NPoco.Linq
         }
 #endif
 
-        private IEnumerable<T> ExecuteQuery(Sql sql)
+        protected IEnumerable<T> ExecuteQuery(Sql sql)
         {
             return _database.QueryImp(default(T), _listExpression, null, sql);
         }
 
-        private Sql BuildSql()
+        public virtual Sql BuildSql()
         {
             Sql sql;
             if (_joinSqlExpressions.Any())
@@ -480,6 +518,42 @@ namespace NPoco.Linq
             return this;
         }
 
+        public IQueryProvider<T> GroupBy(Expression<Func<T, object>> column)
+        {
+            _sqlExpression = _sqlExpression.GroupBy(column);
+            return this;
+        }
+
+        public IQueryProvider<T> Sum(Expression<Func<T, object>> column, string alias = null)
+        {
+            _sqlExpression = _sqlExpression.Sum(column, alias);
+            return this;
+        }
+
+        public IQueryProvider<T> Avg(Expression<Func<T, object>> column, string alias = null)
+        {
+            _sqlExpression = _sqlExpression.Avg(column, alias);
+            return this;
+        }
+
+        public IQueryProvider<T> CountExp(Expression<Func<T, object>> column, string alias = null)
+        {
+            _sqlExpression = _sqlExpression.CountExp(column, alias);
+            return this;
+        }
+
+        public IQueryProvider<T> Select(Expression<Func<T, object>> column, string alias = null)
+        {
+            _sqlExpression = _sqlExpression.Select(column, alias);
+            return this;
+        }
+
+        public List<T2> GroupByAndProject<T2>(Expression<Func<T, T2>> column)
+        {
+            _sqlExpression = _sqlExpression.GroupBy(column);
+            return ProjectTo<T2>(column);
+        }
+
         public IQueryProvider<T> OrderByDescending(Expression<Func<T, object>> column)
         {
             _sqlExpression = _sqlExpression.OrderByDescending(column);
@@ -496,6 +570,11 @@ namespace NPoco.Linq
         {
             _sqlExpression = _sqlExpression.ThenByDescending(column);
             return this;
+        }
+
+        public List<K> Execute<K>()
+        {
+            return _database.QueryImp<K>(default(K), null, null, BuildSql()).ToList();
         }
     }
 }

--- a/src/NPoco/NPoco.csproj
+++ b/src/NPoco/NPoco.csproj
@@ -85,7 +85,8 @@
 
   <PropertyGroup>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-    <Version>3.9.3</Version>
+    <Version>3.9.4</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
 </Project>

--- a/src/NPoco/TableInfo.cs
+++ b/src/NPoco/TableInfo.cs
@@ -6,6 +6,7 @@ namespace NPoco
 {
     public class TableInfo
     {
+        public bool IsInlineView { get; set; }
         public string TableName { get; set; }
         public string PrimaryKey { get; set; }
         public bool AutoIncrement { get; set; }
@@ -24,7 +25,8 @@ namespace NPoco
                 PrimaryKey = PrimaryKey,
                 SequenceName = SequenceName,
                 UseOutputClause = UseOutputClause,
-                PersistedType = PersistedType
+                PersistedType = PersistedType,
+                IsInlineView = IsInlineView
             };
         }
 
@@ -48,7 +50,7 @@ namespace NPoco
 
             a = t.GetTypeInfo().GetCustomAttributes(typeof(PersistedTypeAttribute), true).ToArray();
             tableInfo.PersistedType = a.Length == 0 ? null : (a[0] as PersistedTypeAttribute).PersistedType;
-
+            tableInfo.IsInlineView = false;
             return tableInfo;
         }
     }

--- a/test/NPoco.Tests/Common/ExtraUserInfo.cs
+++ b/test/NPoco.Tests/Common/ExtraUserInfo.cs
@@ -1,5 +1,6 @@
 namespace NPoco.Tests.Common
 {
+    [TableName("ExtraUserInfos")]
     public class ExtraUserInfo
     {
         public int ExtraUserInfoId { get; set; }

--- a/test/NPoco.Tests/Common/User.cs
+++ b/test/NPoco.Tests/Common/User.cs
@@ -3,6 +3,33 @@ using NPoco;
 
 namespace NPoco.Tests.Common
 {
+    public class SubQueryTest
+    {
+        public int ChildrenSum { get; set; }
+
+        public double ChildrenAvg { get; set; }
+
+        public string HomeAddress { get; set; }
+    }
+
+
+    [TableName("Users")]
+    public class CompositeUserTest
+    {
+        public int UserId { get; set; }
+
+        public int? HouseId { get; set; }
+
+        public virtual string Name { get; set; }
+
+        [Reference(ReferenceType.OneToOne, ColumnName = "UserId", ReferenceMemberName = "UserId")]
+        public ExtraUserInfoDecorated ExtraUserInfo { get; set; }
+
+
+        [Reference(ReferenceType.OneToOne, ColumnName = "HouseId", ReferenceMemberName = "HouseId")]
+        public HouseDecorated House { get; set; }
+    }
+
     public class User
     {
         public User()


### PR DESCRIPTION
Following features were added;
- Subquery support (inline query for 'from' clauses).
- Sum, Avg, CountExp aggreagation methods.
- GroupBy method accessor in SimpleQueryProvider
- SubQueryWithAggregationTest unit test

And  'Select' method is modified to use with aggreagtion methods.
Example:
SELECT [CUT].[House__Address] as [HomeAddress], SUM([CUT].[ExtraUserInfo__Children])....