### PR TITLE
Allow executing queries even if not all of the variables are specified

### DIFF
--- a/src/NPoco/ParameterHelper.cs
+++ b/src/NPoco/ParameterHelper.cs
@@ -22,8 +22,14 @@ namespace NPoco
                 if (parameters.TryGetValue(m.Value, out item))
                     return item;
 
-                item = parameters[m.Value] = ProcessParam(ref sql, m.Value, args_src, args_dest);
-                return item;
+                var param = ProcessParam(ref sql, m.Value, args_src, args_dest);
+                if (!string.IsNullOrEmpty(param))
+                {
+                    item = parameters[m.Value] = param;
+                    return item;
+                }
+                else
+                    return "@" + m.Value;
             });
         }
         
@@ -74,8 +80,7 @@ namespace NPoco
                     }
                 }
 
-                if (!found)
-                    throw new ArgumentException(String.Format("Parameter '@{0}' specified but none of the passed arguments have a property with this name (in '{1}')", param, sql));
+                if (!found) return string.Empty;
             }
 
             // Expand collections to parameter lists

--- a/test/NPoco.Tests/FluentTests/QueryTests/QueryWithDeclarationTests.cs
+++ b/test/NPoco.Tests/FluentTests/QueryTests/QueryWithDeclarationTests.cs
@@ -1,0 +1,77 @@
+﻿using NPoco.Tests.Common;
+using NUnit.Framework;
+
+namespace NPoco.Tests.FluentTests.QueryTests
+{
+    [TestFixture]
+    public class QueryWithDeclarationTests : BaseDBFuentTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            (Database as NPoco.Database).EnableAutoSelect = false;
+        }
+
+        [Test]
+        public void FetchAllWithSqlHavingDeclaredVariable()
+        {
+            var users = Database.Fetch<User>(
+                @"declare @userid int = 1 
+                  select * from users where userid > @userid 
+                  order by userid");
+
+            Assert.AreEqual(InMemoryUsers.Count - 1, users.Count);
+            for (int i = 1; i < InMemoryUsers.Count; i++)
+            {
+                AssertUserValues(InMemoryUsers[i], users[i - 1]);
+            }
+        }
+
+        [Test]
+        public void FetchAllWithSqlHavingCommentedVariable()
+        {
+            var users = Database.Fetch<User>(
+                @"select * from users --where userid > @userid 
+                  order by userid");
+
+            Assert.AreEqual(InMemoryUsers.Count, users.Count);
+            for (int i = 0; i < InMemoryUsers.Count; i++)
+            {
+                AssertUserValues(InMemoryUsers[i], users[i]);
+            }
+        }
+
+        [Test]
+        public void FetchAllWithSqlHavingTableVariable()
+        {
+            var users = Database.Fetch<User>(
+                @"declare @t table (id int)
+                  insert into @t values
+                  (1), (2), (3)
+
+                  select * from users where userid in 
+                  (select id from @t)
+                  order by userid");
+
+            Assert.AreEqual(3, users.Count);
+            for (int i = 0; i < 3; i++)
+            {
+                AssertUserValues(InMemoryUsers[i], users[i]);
+            }
+        }
+
+        [Test]
+        public void FetchAllWithSqlHavingAtSignInString()
+        {
+            var users = Database.Fetch<User>(
+                @"select * from users where name <> ' @userid '
+                  order by userid");
+
+            Assert.AreEqual(InMemoryUsers.Count, users.Count);
+            for (int i = 0; i < InMemoryUsers.Count; i++)
+            {
+                AssertUserValues(InMemoryUsers[i], users[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, if I try to execute the SQL query NPoco checks if all of the variables are specified, and if some of them are not - it throws the exception. I consider this behavior as overly defensive and here are the reasons why.

1. In case the query is malformed it will fail during the execution anyway, I see no point in preliminary failing.
2. If the variable is declared and assigned right inside the query the query would succeed without a need to specify its value externally, but NPoco demands it to be specified.
**Example 1:** `declare @userid int = 1; select * from users where userid = @userid`
In this case, there is a possible workaround - I still can specify a variable externally, passing some dummy value: `db.Fetch<User>(sql, new {userid = 0});`
3. But when the variable has some custom type (e.g. `Table`) there is no easy workaround:
**Example 2:**
```
declare @t table (id int)
insert into @t values
(1), (2), (3)
select * from users where userid in 
(select id from @t)
order by userid
```
(The example is extremely simplified; normally I declare table variables only when it is really necessary). Instead, I have to create a temporary table, which is not always applicable.
4. And finally, the existing mechanism for parsing input parameters in SQL does not care about where this 'variable' is defined. Which means if I have an SQL where the @-sign is used inside the string or in the commented block the query will fail even though it is perfectly fine for RDMS.
**Example 3:**
```
/*Uncomment for debugging:
declare @userid int = 1 */
select * from users
-- where userid = @userid
```
**Example 4:**
```
select * from users where email like '%@gmail.com'
```

Examples I provided may seem quite synthetic, but I try to use NPoco for getting data for reports using quite complicated SQL queries. Many of them use table variables and a whole bunch of ordinary variables; and for the sake of debugging, I have commented sections with examples of input parameters too. So I find it quite frustrating that NPoco fails to execute such queries.

The proposed solution simply removes the throwing of the exception if the variable (or something that looks like a variable) is not found among the input parameters, leaving the validation to DBMS parsing engine.