### PR TITLE
fix - if left join, return empty list

### DIFF
--- a/src/NPoco/RelationExtensions.cs
+++ b/src/NPoco/RelationExtensions.cs
@@ -70,8 +70,8 @@ namespace NPoco
 
             var prev = (T)onetomanycurrent;
             onetomanycurrent = main; 
-
-            bool nullMany = sub == null || (subIdFunc != null && subIdFunc(sub).Equals(GetDefault(subIdFunc(sub).GetType())));
+            // In case of a left Join, check if properties inside sub Object are null 
+            bool nullMany = sub.GetType().GetProperties()[0].GetValue(sub,null) == null || (subIdFunc != null && subIdFunc(sub).Equals(GetDefault(subIdFunc(sub).GetType())));
             property1.SetValue((T) onetomanycurrent, nullMany ? new List<TSub>() : new List<TSub> {sub}, null);
 
             return prev;


### PR DESCRIPTION
In case of a Left join in the SQL query, resulting list will have nested objects with null values. Modification allows to reject null values and return empty List instead. 
1. The SubTypes list has null values for Id and Name. Count of SubTypes is 1 but there is no valid Data. 
<img width="369" alt="Before_Null_Values" src="https://user-images.githubusercontent.com/39309712/56681882-55ad6580-6698-11e9-9c87-cf439d69cb68.png">
2. after the fix, SubTypes is just one empty list with no values. (Expected or valid Case).
<img width="353" alt="After_Empty_List" src="https://user-images.githubusercontent.com/39309712/56681918-652cae80-6698-11e9-9a19-9c0d8ec53ac6.png">

