### PR TITLE
Adds SQL Server command formatting for easy copy & paste

### DIFF
--- a/src/NPoco.SqlServer/SqlServerDatabase.cs
+++ b/src/NPoco.SqlServer/SqlServerDatabase.cs
@@ -41,45 +41,6 @@ namespace NPoco.SqlServer
             }
 
             return await base.ExecutionHookAsync(action).ConfigureAwait(false);
-        }
-
-        public override string FormatCommand(string sql, object[] args)
-        {
-            if (sql == null)
-                return "";
-            var sb = new StringBuilder();
-            if (args != null && args.Length > 0)
-            {
-                for (int i = 0; i < args.Length; i++)
-                {
-                    var value = args[i];
-                    var formatted = args[i] as FormattedParameter;
-                    if (formatted != null)
-                    {
-                        value = formatted.Value;
-                    }
-
-                    var p = new Microsoft.Data.SqlClient.SqlParameter();
-                    SetParameterValue(p, args[i]);
-                    if (p.Size == 0 || p.SqlDbType == SqlDbType.UniqueIdentifier)
-                    {
-                        if (value == null && (p.SqlDbType == SqlDbType.NVarChar || p.SqlDbType == SqlDbType.VarChar))
-                        {
-                            sb.AppendFormat("DECLARE {0}{1} {2} = null\n", _paramPrefix, i, p.SqlDbType);
-                        }
-                        else
-                        {
-                            sb.AppendFormat("DECLARE {0}{1} {2} = '{3}'\n", _paramPrefix, i, p.SqlDbType, value);
-                        }
-                    }
-                    else
-                    {
-                        sb.AppendFormat("DECLARE {0}{1} {2}[{3}] = '{4}'\n", _paramPrefix, i, p.SqlDbType, p.Size, value);
-                    }
-                }
-            }
-            sb.AppendFormat("\n{0}", sql);
-            return sb.ToString();
-        }
+        }        
     }
 }

--- a/src/NPoco.SqlServer/SqlServerDatabase.cs
+++ b/src/NPoco.SqlServer/SqlServerDatabase.cs
@@ -2,7 +2,9 @@
 using NPoco.SqlServer;
 using System;
 using System.Threading.Tasks;
+using System.Text;
 using NPoco.DatabaseTypes;
+using System.Data;
 
 namespace NPoco.SqlServer
 {
@@ -10,12 +12,12 @@ namespace NPoco.SqlServer
     {
         private readonly IPollyPolicy _pollyPolicy;
 
-        public SqlServerDatabase(string connectionString, IPollyPolicy pollyPolicy = null) 
+        public SqlServerDatabase(string connectionString, IPollyPolicy pollyPolicy = null)
             : this(connectionString, Singleton<SqlServer2012DatabaseType>.Instance, pollyPolicy)
         {
         }
 
-        public SqlServerDatabase(string connectionString, SqlServerDatabaseType databaseType, IPollyPolicy pollyPolicy) 
+        public SqlServerDatabase(string connectionString, SqlServerDatabaseType databaseType, IPollyPolicy pollyPolicy)
             : base(connectionString, databaseType, SqlClientFactory.Instance)
         {
             _pollyPolicy = pollyPolicy;
@@ -39,6 +41,45 @@ namespace NPoco.SqlServer
             }
 
             return await base.ExecutionHookAsync(action).ConfigureAwait(false);
+        }
+
+        public override string FormatCommand(string sql, object[] args)
+        {
+            if (sql == null)
+                return "";
+            var sb = new StringBuilder();
+            if (args != null && args.Length > 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    var value = args[i];
+                    var formatted = args[i] as FormattedParameter;
+                    if (formatted != null)
+                    {
+                        value = formatted.Value;
+                    }
+
+                    var p = new Microsoft.Data.SqlClient.SqlParameter();
+                    SetParameterValue(p, args[i]);
+                    if (p.Size == 0 || p.SqlDbType == SqlDbType.UniqueIdentifier)
+                    {
+                        if (value == null && (p.SqlDbType == SqlDbType.NVarChar || p.SqlDbType == SqlDbType.VarChar))
+                        {
+                            sb.AppendFormat("DECLARE {0}{1} {2} = null\n", _paramPrefix, i, p.SqlDbType);
+                        }
+                        else
+                        {
+                            sb.AppendFormat("DECLARE {0}{1} {2} = '{3}'\n", _paramPrefix, i, p.SqlDbType, value);
+                        }
+                    }
+                    else
+                    {
+                        sb.AppendFormat("DECLARE {0}{1} {2}[{3}] = '{4}'\n", _paramPrefix, i, p.SqlDbType, p.Size, value);
+                    }
+                }
+            }
+            sb.AppendFormat("\n{0}", sql);
+            return sb.ToString();
         }
     }
 }

--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -36,7 +36,7 @@ namespace NPoco
         public Database(DbConnection connection, DatabaseType? dbType)
             : this(connection, dbType, null, DefaultEnableAutoSelect)
         { }
-        
+
         public Database(DbConnection connection, DatabaseType? dbType, IsolationLevel? isolationLevel)
             : this(connection, dbType, isolationLevel, DefaultEnableAutoSelect)
         { }
@@ -386,86 +386,7 @@ namespace NPoco
 
             cmd.Parameters.Add(p);
         }
-
-        private void SetParameterValue(DbParameter p, object? value)
-        {
-            if (value == null)
-            {
-                p.Value = DBNull.Value;
-                return;
-            }
-
-            // Give the database type first crack at converting to DB required type
-            value = _dbType.MapParameterValue(value);
-
-            var dbtypeSet = false;
-            var t = value.GetType();
-            var underlyingT = Nullable.GetUnderlyingType(t);
-            if (t.GetTypeInfo().IsEnum || (underlyingT != null && underlyingT.GetTypeInfo().IsEnum))        // PostgreSQL .NET driver wont cast enum to int
-            {
-                p.Value = (int)value;
-            }
-            else if (t == typeof(Guid))
-            {
-                p.Value = value;
-                p.DbType = DbType.Guid;
-                p.Size = 40;
-                dbtypeSet = true;
-            }
-            else if (t == typeof(string))
-            {
-                var strValue = value as string;
-                if (strValue == null)
-                {
-                    p.Size = 0;
-                    p.Value = DBNull.Value;
-                }
-                else
-                {
-                    // out of memory exception occurs if trying to save more than 4000 characters to SQL Server CE NText column. Set before attempting to set Size, or Size will always max out at 4000
-                    if (strValue.Length + 1 > 4000 && p.GetType().Name == "SqlCeParameter")
-                    {
-                        p.GetType().GetProperty("SqlDbType").SetValue(p, SqlDbType.NText, null);
-                    }
-
-                    p.Size = Math.Max(strValue.Length + 1, 4000); // Help query plan caching by using common size
-                    p.Value = value;
-                }
-            }
-            else if (t == typeof(AnsiString))
-            {
-                var ansistrValue = value as AnsiString;
-                if (ansistrValue?.Value == null)
-                {
-                    p.Size = 0;
-                    p.Value = DBNull.Value;
-                    p.DbType = DbType.AnsiString;
-                }
-                else
-                {
-                    // Thanks @DataChomp for pointing out the SQL Server indexing performance hit of using wrong string type on varchar
-                    p.Size = Math.Max(ansistrValue.Value.Length + 1, 4000);
-                    p.Value = ansistrValue.Value;
-                    p.DbType = DbType.AnsiString;
-                }
-                dbtypeSet = true;
-            }
-            else if (value.GetType().Name == "SqlGeography") //SqlGeography is a CLR Type
-            {
-                p.GetType().GetProperty("UdtTypeName").SetValue(p, "geography", null); //geography is the equivalent SQL Server Type
-                p.Value = value;
-            }
-
-            else if (value.GetType().Name == "SqlGeometry") //SqlGeometry is a CLR Type
-            {
-                p.GetType().GetProperty("UdtTypeName").SetValue(p, "geometry", null); //geography is the equivalent SQL Server Type
-                p.Value = value;
-            }
-            else
-            {
-                p.Value = value;
-            }
-
+       
         // Create a command
         private DbCommand CreateCommand(DbConnection connection, string sql, params object[] args)
         {
@@ -630,11 +551,11 @@ namespace NPoco
                 else
                 {
                     var props = args[0].GetType().GetProperties().Select(x => new { x.Name, Value = x.GetValue(args[0], null) }).ToList();
-                    foreach(var item in props)
+                    foreach (var item in props)
                     {
                         DbParameter param = cmd.CreateParameter();
                         param.ParameterName = item.Name;
-                        
+
                         ParameterHelper.SetParameterValue(_dbType, param, item.Value);
 
                         cmd.Parameters.Add(param);
@@ -965,8 +886,8 @@ namespace NPoco
 
                 if (prevPoco != null)
                 {
-                    if (idFunc != null 
-                        && listFunc != null 
+                    if (idFunc != null
+                        && listFunc != null
                         && pocoMember != null
                         && idFunc(poco).SequenceEqual(idFunc((T)prevPoco)))
                     {
@@ -1044,7 +965,7 @@ namespace NPoco
             var sql = Sql.SQL;
             var args = Sql.Arguments;
 
-            if (EnableAutoSelect) sql = AutoSelectHelper.AddSelectClause(this, typeof (T), sql);
+            if (EnableAutoSelect) sql = AutoSelectHelper.AddSelectClause(this, typeof(T), sql);
 
             try
             {
@@ -1190,16 +1111,16 @@ namespace NPoco
                             switch (typeIndex)
                             {
                                 case 1:
-                                    list1.Add((T1) factory.Map(r, default(T1)));
+                                    list1.Add((T1)factory.Map(r, default(T1)));
                                     break;
                                 case 2:
-                                    list2!.Add((T2) factory.Map(r, default(T2)));
+                                    list2!.Add((T2)factory.Map(r, default(T2)));
                                     break;
                                 case 3:
-                                    list3!.Add((T3) factory.Map(r, default(T3)));
+                                    list3!.Add((T3)factory.Map(r, default(T3)));
                                     break;
                                 case 4:
-                                    list4!.Add((T4) factory.Map(r, default(T4)));
+                                    list4!.Add((T4)factory.Map(r, default(T4)));
                                     break;
                             }
                         }
@@ -1216,11 +1137,11 @@ namespace NPoco
                 switch (types.Length)
                 {
                     case 2:
-                        return ((Func<List<T1>, List<T2>, TRet>) cb)(list1, list2!);
+                        return ((Func<List<T1>, List<T2>, TRet>)cb)(list1, list2!);
                     case 3:
-                        return ((Func<List<T1>, List<T2>, List<T3>, TRet>) cb)(list1, list2!, list3!);
+                        return ((Func<List<T1>, List<T2>, List<T3>, TRet>)cb)(list1, list2!, list3!);
                     case 4:
-                        return ((Func<List<T1>, List<T2>, List<T3>, List<T4>, TRet>) cb)(list1, list2!, list3!, list4!);
+                        return ((Func<List<T1>, List<T2>, List<T3>, List<T4>, TRet>)cb)(list1, list2!, list3!, list4!);
                 }
 
                 return default(TRet)!;
@@ -1251,7 +1172,7 @@ namespace NPoco
         private Sql GenerateSingleByIdSql<T>(object primaryKey)
         {
             var index = 0;
-            var pd = PocoDataFactory.ForType(typeof (T));
+            var pd = PocoDataFactory.ForType(typeof(T));
             var primaryKeyValuePairs = GetPrimaryKeyValues(this, pd, pd.TableInfo.PrimaryKey, primaryKey, primaryKey is T);
             var sql = AutoSelectHelper.AddSelectClause(this, typeof(T), string.Format("WHERE {0}", BuildPrimaryKeySql(this, primaryKeyValuePairs, ref index)));
             var args = primaryKeyValuePairs.Select(x => x.Value).ToArray();
@@ -1489,8 +1410,8 @@ namespace NPoco
             if (poco == null) throw new ArgumentNullException(nameof(poco));
             var expression = DatabaseType.ExpressionVisitor<T>(this, PocoDataFactory.ForType(typeof(T)));
             expression = expression.Select(fields);
-            var columnNames = ((ISqlExpression) expression).SelectMembers.Select(x => x.PocoColumn.ColumnName);
-            var otherNames = ((ISqlExpression) expression).GeneralMembers.Select(x => x.PocoColumn.ColumnName);
+            var columnNames = ((ISqlExpression)expression).SelectMembers.Select(x => x.PocoColumn.ColumnName);
+            var otherNames = ((ISqlExpression)expression).GeneralMembers.Select(x => x.PocoColumn.ColumnName);
             return Update(poco, columnNames.Union(otherNames));
         }
 
@@ -1711,52 +1632,14 @@ namespace NPoco
 
         public string LastCommand => FormatCommand(_lastSql, _lastArgs);
 
-        private class FormattedParameter
-        {
-            public FormattedParameter(Type type, object value, DbParameter parameter)
-            {
-                Type = type;
-                Value = value;
-                Parameter = parameter;
-            }
-
-            public Type Type { get; set; }
-            public object Value { get; set; }
-            public DbParameter Parameter { get; set; }
-        }
-
         public string FormatCommand(DbCommand cmd)
         {
-            var parameters = cmd.Parameters.Cast<DbParameter>().Select(parameter =>
-            {
-                return new FormattedParameter(parameter.Value.GetTheType(), parameter.Value, parameter);
-            });
-            return FormatCommand(cmd.CommandText, parameters.Cast<object>().ToArray());
+            return _dbType.FormatCommand(cmd);
         }
 
-        public string FormatCommand(string? sql, object[]? args)
+        public string FormatCommand(string sql, object[] args)
         {
-            var sb = new StringBuilder();
-            if (sql == null)
-                return "";
-            sb.Append(sql);
-            if (args != null && args.Length > 0)
-            {
-                sb.Append("\n");
-                for (int i = 0; i < args.Length; i++)
-                {
-                    var type = args[i] != null ? args[i].GetType().Name : string.Empty;
-                    var value = args[i];
-                    if (args[i] is FormattedParameter formatted)
-                    {
-                        type = formatted.Type != null ? formatted.Type.Name : string.Format("{0}, {1}", formatted.Parameter.GetType().Name, formatted.Parameter.DbType);
-                        value = formatted.Value;
-                    }
-                    sb.AppendFormat("\t -> {0}{1} [{2}] = \"{3}\"\n", _paramPrefix, i, type, value);
-                }
-                sb.Remove(sb.Length - 1, 1);
-            }
-            return sb.ToString();
+            return _dbType.FormatCommand(sql, args);
         }
 
         private List<IInterceptor>? _interceptors;
@@ -1787,7 +1670,7 @@ namespace NPoco
         private IsolationLevel _isolationLevel;
         private string? _lastSql;
         private object[]? _lastArgs;
-        private string _paramPrefix = "@";
+        internal string _paramPrefix = "@";
         private readonly bool _connectionPassedIn;
 
         internal int ExecuteNonQueryHelper(DbCommand cmd)
@@ -1850,7 +1733,7 @@ namespace NPoco
             var converter = database.Mappers.Find(x => x.GetToDbConverter(pc.ColumnType, pc.MemberInfoData.MemberInfo));
             return converter != null ? converter(value) : ProcessDefaultMappings(database, pc, value);
         }
-        
+
         internal static object ProcessDefaultMappings(IDatabase database, PocoColumn pocoColumn, object? value)
         {
             if (pocoColumn.SerializedColumn)

--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -33,7 +33,7 @@ namespace NPoco
         public Database(DbConnection connection, DatabaseType dbType)
             : this(connection, dbType, null, DefaultEnableAutoSelect)
         { }
-        
+
         public Database(DbConnection connection, DatabaseType dbType, IsolationLevel? isolationLevel)
             : this(connection, dbType, isolationLevel, DefaultEnableAutoSelect)
         { }
@@ -391,11 +391,11 @@ namespace NPoco
             p.ParameterName = string.Format("{0}{1}", _paramPrefix, cmd.Parameters.Count);
 
             SetParameterValue(p, value);
-            
+
             cmd.Parameters.Add(p);
         }
 
-        private void SetParameterValue(DbParameter p, object value)
+        internal void SetParameterValue(DbParameter p, object value)
         {
             if (value == null)
             {
@@ -489,7 +489,7 @@ namespace NPoco
         {
             return CreateCommand(connection, CommandType.Text, sql, args);
         }
-        
+
         public virtual DbCommand CreateCommand(DbConnection connection, CommandType commandType, string sql, params object[] args)
         {
             if (commandType == CommandType.StoredProcedure)
@@ -505,7 +505,7 @@ namespace NPoco
             // Create the command and add parameters
             DbCommand cmd = connection.CreateCommand();
             cmd.Connection = connection;
-            cmd.CommandText = sql;            
+            cmd.CommandText = sql;
             cmd.Transaction = _transaction;
 
             foreach (var item in args)
@@ -629,7 +629,7 @@ namespace NPoco
             var result = OnDeleting(deleteContext);
             return result && Interceptors.OfType<IDataInterceptor>().All(x => x.OnDeleting(this, deleteContext));
         }
-        
+
         public DbCommand CreateStoredProcedureCommand(DbConnection connection, string name, params object[] args)
         {
             DbCommand cmd = connection.CreateCommand();
@@ -654,7 +654,7 @@ namespace NPoco
                         param.ParameterName = item.Name;
 
                         SetParameterValue(param, item.Value);
-                        
+
                         cmd.Parameters.Add(param);
                     }
                 }
@@ -708,7 +708,7 @@ namespace NPoco
         {
             return ExecuteScalar<T>(new Sql(sql, args));
         }
-        
+
         public T ExecuteScalar<T>(Sql Sql)
         {
             return ExecuteScalar<T>(Sql.SQL, CommandType.Text, Sql.Arguments);
@@ -1183,7 +1183,7 @@ namespace NPoco
                 OpenSharedConnectionInternal();
                 using var cmd = CreateCommand(_sharedConnection, sql, args);
                 using var r = sync ? ExecuteDataReader(cmd, true).RunSync() : await ExecuteDataReader(cmd, false).ConfigureAwait(false);
-                
+
                 var typeIndex = 1;
                 var list1 = new List<T1>();
                 var list2 = types.Length > 1 ? new List<T2>() : null;
@@ -1436,7 +1436,7 @@ namespace NPoco
             return result;
         }
 
-       
+
         internal static string BuildPrimaryKeySql(Database database, Dictionary<string, object> primaryKeyValuePair, ref int index)
         {
             var tempIndex = index;
@@ -1625,7 +1625,7 @@ namespace NPoco
             return IsNewAsync(poco, true).RunSync();
         }
 
-        private async Task<bool> IsNewAsync<T>(T poco, bool sync) 
+        private async Task<bool> IsNewAsync<T>(T poco, bool sync)
         {
             if (poco is System.Dynamic.ExpandoObject || poco is PocoExpando)
             {
@@ -1642,8 +1642,8 @@ namespace NPoco
             }
             else if (pd.TableInfo.PrimaryKey.Contains(","))
             {
-                return sync 
-                    ? !PocoExistsAsync(poco, true).RunSync() 
+                return sync
+                    ? !PocoExistsAsync(poco, true).RunSync()
                     : !await PocoExistsAsync(poco, false).ConfigureAwait(false);
             }
             else
@@ -1726,14 +1726,14 @@ namespace NPoco
             get { return FormatCommand(_lastSql, _lastArgs); }
         }
 
-        private class FormattedParameter
+        internal class FormattedParameter
         {
             public Type Type { get; set; }
             public object Value { get; set; }
             public DbParameter Parameter { get; set; }
         }
 
-        public string FormatCommand(DbCommand cmd)
+        public virtual string FormatCommand(DbCommand cmd)
         {
             var parameters = cmd.Parameters.Cast<DbParameter>().Select(parameter => new FormattedParameter()
             {
@@ -1744,11 +1744,11 @@ namespace NPoco
             return FormatCommand(cmd.CommandText, parameters.Cast<object>().ToArray());
         }
 
-        public string FormatCommand(string sql, object[] args)
+        public virtual string FormatCommand(string sql, object[] args)
         {
-            var sb = new StringBuilder();
             if (sql == null)
                 return "";
+            var sb = new StringBuilder();
             sb.Append(sql);
             if (args != null && args.Length > 0)
             {
@@ -1801,7 +1801,7 @@ namespace NPoco
         private IsolationLevel _isolationLevel;
         private string _lastSql;
         private object[] _lastArgs;
-        private string _paramPrefix = "@";
+        internal string _paramPrefix = "@";
         private VersionExceptionHandling _versionException = VersionExceptionHandling.Exception;
         private readonly bool _connectionPassedIn;
 
@@ -1865,7 +1865,7 @@ namespace NPoco
             var converter = database.Mappers.Find(x => x.GetToDbConverter(pc.ColumnType, pc.MemberInfoData.MemberInfo));
             return converter != null ? converter(value) : ProcessDefaultMappings(database, pc, value);
         }
-        
+
         internal static object ProcessDefaultMappings(IDatabase database, PocoColumn pocoColumn, object value)
         {
             if (pocoColumn.SerializedColumn)

--- a/src/NPoco/DatabaseType.cs
+++ b/src/NPoco/DatabaseType.cs
@@ -8,6 +8,7 @@ using NPoco.DatabaseTypes;
 using NPoco.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace NPoco
 {
@@ -102,6 +103,14 @@ namespace NPoco
             return null;
         }
 
+        /// <summary>
+        /// Returns the prefix used to delimit parameters in SQL query strings.
+        /// </summary>        
+        /// <returns></returns>
+        public virtual string GetParameterPrefix()
+        {
+            return "@";
+        }
         /// <summary>
         /// Returns the prefix used to delimit parameters in SQL query strings.
         /// </summary>
@@ -364,5 +373,50 @@ namespace NPoco
         {
             return value;
         }
+
+        internal class FormattedParameter
+        {
+            public Type Type { get; set; }
+            public object Value { get; set; }
+            public DbParameter Parameter { get; set; }
+        }
+
+        public virtual string FormatCommand(DbCommand cmd)
+        {
+            var parameters = cmd.Parameters.Cast<DbParameter>().Select(parameter => new FormattedParameter()
+            {
+                Type = parameter.Value.GetTheType(),
+                Value = parameter.Value,
+                Parameter = parameter
+            });
+            return FormatCommand(cmd.CommandText, parameters.Cast<object>().ToArray());
+        }
+
+        public virtual string FormatCommand(string sql, object[] args)
+        {
+            if (sql == null)
+                return "";
+            var sb = new StringBuilder();
+            sb.Append(sql);
+            if (args != null && args.Length > 0)
+            {
+                sb.Append("\n");
+                for (int i = 0; i < args.Length; i++)
+                {
+                    var type = args[i] != null ? args[i].GetType().Name : string.Empty;
+                    var value = args[i];
+                    var formatted = args[i] as FormattedParameter;
+                    if (formatted != null)
+                    {
+                        type = formatted.Type != null ? formatted.Type.Name : string.Format("{0}, {1}", formatted.Parameter.GetType().Name, formatted.Parameter.DbType);
+                        value = formatted.Value;
+                    }
+                    sb.AppendFormat("\t -> {0}{1} [{2}] = \"{3}\"\n", GetParameterPrefix(), i, type, value);
+                }
+                sb.Remove(sb.Length - 1, 1);
+            }
+            return sb.ToString();
+        }
+
     }
 }

--- a/src/NPoco/DatabaseType.cs
+++ b/src/NPoco/DatabaseType.cs
@@ -393,7 +393,7 @@ namespace NPoco
         }
 
         public virtual string FormatCommand(string sql, object[] args)
-        {
+        {            
             if (sql == null)
                 return "";
             var sb = new StringBuilder();
@@ -405,8 +405,7 @@ namespace NPoco
                 {
                     var type = args[i] != null ? args[i].GetType().Name : string.Empty;
                     var value = args[i];
-                    var formatted = args[i] as FormattedParameter;
-                    if (formatted != null)
+                    if (args[i] is FormattedParameter formatted)
                     {
                         type = formatted.Type != null ? formatted.Type.Name : string.Format("{0}, {1}", formatted.Parameter.GetType().Name, formatted.Parameter.DbType);
                         value = formatted.Value;

--- a/src/NPoco/Linq/SimpleQueryProvider.cs
+++ b/src/NPoco/Linq/SimpleQueryProvider.cs
@@ -252,7 +252,7 @@ namespace NPoco.Linq
 
         public Task<T> First(Expression<Func<T, bool>> whereExpression)
         {
-            AddWhere(null);
+            AddWhere(whereExpression);
             return ToEnumerable().FirstAsync().AsTask();
         }
 

--- a/src/NPoco/ParameterHelper.cs
+++ b/src/NPoco/ParameterHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -133,5 +135,95 @@ namespace NPoco
                 return "@" + (args_dest.Count - 1).ToString();
             }
         }
+
+        public static void SetParameterValue(DatabaseType dbType, DbParameter p, object value)
+        {
+            if (value == null)
+            {
+                p.Value = DBNull.Value;
+                return;
+            }
+
+            // Give the database type first crack at converting to DB required type
+            value = dbType.MapParameterValue(value);
+
+            var dbtypeSet = false;
+            var t = value.GetType();
+            var underlyingT = Nullable.GetUnderlyingType(t);
+            if (t.GetTypeInfo().IsEnum || (underlyingT != null && underlyingT.GetTypeInfo().IsEnum))        // PostgreSQL .NET driver wont cast enum to int
+            {
+                p.Value = (int)value;
+            }
+            else if (t == typeof(Guid))
+            {
+                p.Value = value;
+                p.DbType = DbType.Guid;
+                p.Size = 40;
+                dbtypeSet = true;
+            }
+            else if (t == typeof(string))
+            {
+                var strValue = value as string;
+                if (strValue == null)
+                {
+                    p.Size = 0;
+                    p.Value = DBNull.Value;
+                }
+                else
+                {
+                    // out of memory exception occurs if trying to save more than 4000 characters to SQL Server CE NText column. Set before attempting to set Size, or Size will always max out at 4000
+                    if (strValue.Length + 1 > 4000 && p.GetType().Name == "SqlCeParameter")
+                    {
+                        p.GetType().GetProperty("SqlDbType").SetValue(p, SqlDbType.NText, null);
+                    }
+
+                    p.Size = Math.Max(strValue.Length + 1, 4000); // Help query plan caching by using common size
+                    p.Value = value;
+                }
+            }
+            else if (t == typeof(AnsiString))
+            {
+                var ansistrValue = value as AnsiString;
+                if (ansistrValue?.Value == null)
+                {
+                    p.Size = 0;
+                    p.Value = DBNull.Value;
+                    p.DbType = DbType.AnsiString;
+                }
+                else
+                {
+                    // Thanks @DataChomp for pointing out the SQL Server indexing performance hit of using wrong string type on varchar
+                    p.Size = Math.Max(ansistrValue.Value.Length + 1, 4000);
+                    p.Value = ansistrValue.Value;
+                    p.DbType = DbType.AnsiString;
+                }
+                dbtypeSet = true;
+            }
+            else if (value.GetType().Name == "SqlGeography") //SqlGeography is a CLR Type
+            {
+                p.GetType().GetProperty("UdtTypeName").SetValue(p, "geography", null); //geography is the equivalent SQL Server Type
+                p.Value = value;
+            }
+
+            else if (value.GetType().Name == "SqlGeometry") //SqlGeometry is a CLR Type
+            {
+                p.GetType().GetProperty("UdtTypeName").SetValue(p, "geometry", null); //geography is the equivalent SQL Server Type
+                p.Value = value;
+            }
+            else
+            {
+                p.Value = value;
+            }
+
+            if (!dbtypeSet)
+            {
+                var dbTypeLookup = dbType.LookupDbType(p.Value.GetTheType(), p.ParameterName);
+                if (dbTypeLookup.HasValue)
+                {
+                    p.DbType = dbTypeLookup.Value;
+                }
+            }
+        }
+
     }
 }

--- a/src/NPoco/ParameterHelper.cs
+++ b/src/NPoco/ParameterHelper.cs
@@ -136,7 +136,7 @@ namespace NPoco
             }
         }
 
-        public static void SetParameterValue(DatabaseType dbType, DbParameter p, object value)
+        public static void SetParameterValue(DatabaseType dbType, DbParameter p, object? value)
         {
             if (value == null)
             {
@@ -224,6 +224,5 @@ namespace NPoco
                 }
             }
         }
-
     }
 }

--- a/test/NPoco.Tests/FormatCommandTest.cs
+++ b/test/NPoco.Tests/FormatCommandTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Data;
 using Microsoft.Data.SqlClient;
-using NPoco.DatabaseTypes;
 using NUnit.Framework;
 
 namespace NPoco.Tests
@@ -33,7 +32,7 @@ namespace NPoco.Tests
         public class MyDb : Database
         {
             public MyDb()
-                : base("test", new SqlServerDatabaseType(), SqlClientFactory.Instance)
+                : base("test", DatabaseType.MySQL, SqlClientFactory.Instance)
             {
             }
         }

--- a/test/NPoco.Tests/FormatSqlServerCommandTest.cs
+++ b/test/NPoco.Tests/FormatSqlServerCommandTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using Microsoft.Data.SqlClient;
+using NPoco.DatabaseTypes;
 using NUnit.Framework;
 
 namespace NPoco.Tests
@@ -20,11 +21,32 @@ namespace NPoco.Tests
             var guid = Guid.NewGuid();
             Assert.AreEqual("DECLARE @0 UniqueIdentifier = '" + guid + "'\n\nsql @0", db.FormatCommand("sql @0", new object[] { guid }));
         }
+        [Test]
+        public void FormattingWithSqlParameterThatIsNotNullSqlServerDatabase()
+        {
+            var cmd = new SqlCommand();
+            cmd.Parameters.Add(new SqlParameter("Test", SqlDbType.NVarChar));
+            var db = new MyDb2();
+            Assert.AreEqual("DECLARE @0 NVarChar[4000] = 'value'\n\nsql @0", db.FormatCommand("sql @0", new object[] { "value" }));
+            Assert.AreEqual("DECLARE @0 Int = '32'\n\nsql @0", db.FormatCommand("sql @0", new object[] { 32 }));
+            Assert.AreEqual("DECLARE @0 DateTime = '" + DateTime.Today + "'\n\nsql @0", db.FormatCommand("sql @0", new object[] { DateTime.Today }));
+
+            var guid = Guid.NewGuid();
+            Assert.AreEqual("DECLARE @0 UniqueIdentifier = '" + guid + "'\n\nsql @0", db.FormatCommand("sql @0", new object[] { guid }));
+        }
+
+
 
         [Test]
         public void FormattingWithNullValue()
         {
             var db = new MyDb();
+            Assert.AreEqual("DECLARE @0 NVarChar = null\n\nsql @0", db.FormatCommand("sql @0", new object[] { null }));
+        }
+        [Test]
+        public void FormattingWithNullValueSqlServerDatabase()
+        {
+            var db = new MyDb2();
             Assert.AreEqual("DECLARE @0 NVarChar = null\n\nsql @0", db.FormatCommand("sql @0", new object[] { null }));
         }
 
@@ -34,13 +56,29 @@ namespace NPoco.Tests
             var db = new MyDb();
             Assert.AreEqual("DECLARE @0 NVarChar[4000] = 'value'\n\nsql @0", db.FormatCommand("sql @0", new object[] { "value" }));
         }
-
-        public class MyDb : NPoco.SqlServer.SqlServerDatabase
+        [Test]
+        public void FormattingWithStringValueSqlServerDatabase()
         {
-            public MyDb()
+            var db = new MyDb2();
+            Assert.AreEqual("DECLARE @0 NVarChar[4000] = 'value'\n\nsql @0", db.FormatCommand("sql @0", new object[] { "value" }));
+        }
+
+        public class MyDb2 : NPoco.SqlServer.SqlServerDatabase
+        {
+            public MyDb2()
                 : base("test")
             {
             }
+        }
+
+        public class MyDb : Database
+        {
+            public MyDb()
+                : base("test", new SqlServerDatabaseType(), SqlClientFactory.Instance)
+            {
+            }
+
+
         }
     }
 }

--- a/test/NPoco.Tests/FormatSqlServerCommandTest.cs
+++ b/test/NPoco.Tests/FormatSqlServerCommandTest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Data;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace NPoco.Tests
+{
+    public class FormatSqlServerCommandTest
+    {
+        [Test]
+        public void FormattingWithSqlParameterThatIsNotNull()
+        {
+            var cmd = new SqlCommand();
+            cmd.Parameters.Add(new SqlParameter("Test", SqlDbType.NVarChar));
+            var db = new MyDb();
+            Assert.AreEqual("DECLARE @0 NVarChar[4000] = 'value'\n\nsql @0", db.FormatCommand("sql @0", new object[] { "value" }));
+            Assert.AreEqual("DECLARE @0 Int = '32'\n\nsql @0", db.FormatCommand("sql @0", new object[] { 32 }));
+            Assert.AreEqual("DECLARE @0 DateTime = '" + DateTime.Today + "'\n\nsql @0", db.FormatCommand("sql @0", new object[] { DateTime.Today }));
+
+            var guid = Guid.NewGuid();
+            Assert.AreEqual("DECLARE @0 UniqueIdentifier = '" + guid + "'\n\nsql @0", db.FormatCommand("sql @0", new object[] { guid }));
+        }
+
+        [Test]
+        public void FormattingWithNullValue()
+        {
+            var db = new MyDb();
+            Assert.AreEqual("DECLARE @0 NVarChar = null\n\nsql @0", db.FormatCommand("sql @0", new object[] { null }));
+        }
+
+        [Test]
+        public void FormattingWithStringValue()
+        {
+            var db = new MyDb();
+            Assert.AreEqual("DECLARE @0 NVarChar[4000] = 'value'\n\nsql @0", db.FormatCommand("sql @0", new object[] { "value" }));
+        }
+
+        public class MyDb : NPoco.SqlServer.SqlServerDatabase
+        {
+            public MyDb()
+                : base("test")
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
I made the current formatting tests use mySQL as a DB type to cover the other database types and I added a new set of tests with two database types (in the same file).  One for SqlServerDatabaseType and the other for the SqlServerDatabase. While they're the same under the covers, this ways it's covered in case a changes comes along later.

I made a few private members internal, to get access to them. Not sure if you prefer a different way.

Lastly, I added a new override method GetParameterPrefix() with no connectionstring parameter. There was a couple ways to do this and I went with the easiest for now. They both just return "@" with no logic.