### PR TITLE
Fix UpdateBatchAsync() by using the Poco's PocoData instead of the UpdateBatch one

### DIFF
--- a/src/NPoco/AsyncDatabase.cs
+++ b/src/NPoco/AsyncDatabase.cs
@@ -188,7 +188,7 @@ namespace NPoco
                 {
                     var preparedUpdates = batchedPocos.Select(x =>
                     {
-                        if (pd == null) pd = PocoDataFactory.ForType(x.GetType());
+                        if (pd == null) pd = PocoDataFactory.ForType(x.Poco.GetType());
                         return UpdateStatements.PrepareUpdate(this, pd, pd.TableInfo.TableName, pd.TableInfo.PrimaryKey, x.Poco, null, x.Snapshot?.UpdatedColumns());
                     }).ToArray();
 

--- a/test/NPoco.Tests/Async/UpdateAsyncTests.cs
+++ b/test/NPoco.Tests/Async/UpdateAsyncTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NPoco.Tests.Common;
 using NUnit.Framework;
@@ -25,6 +26,21 @@ namespace NPoco.Tests.Async
             Assert.AreEqual(InMemoryUsers[1].Name, verify.Name);
             Assert.AreNotEqual(InMemoryUsers[1].Age, verify.Age);
             Assert.AreNotEqual(InMemoryUsers[1].Savings, verify.Savings);
+        }
+
+        [Test]
+        public async Task UpdateBatchAsyncTest()
+        {
+            var users = InMemoryUsers.Select(x => UpdateBatch.For(x, Database.StartSnapshot(x))).Select(x => { x.Poco.Age = 30; return x; });
+            var updated = await Database.UpdateBatchAsync(users, new BatchOptions() { BatchSize = 10 });
+            var result = await Database.QueryAsync<User>().ToList();
+
+            Assert.AreEqual(15, result.Count);
+            foreach (var u in result)
+            {
+                Assert.AreEqual(30, u.Age);
+            }
+            Assert.AreEqual(14, updated);
         }
     }
 }


### PR DESCRIPTION
UpdateBatchAsync() doesn't currently work, because it uses the UpdateBatch<T> PocoData instead of the Poco's PocoData.

Fixed it by copying the correct line from the synchronous UpdateBatch().