### PR TITLE
Implementation of a Max Depth for member scanning

### DIFF
--- a/src/NPoco/ColumnInfo.cs
+++ b/src/NPoco/ColumnInfo.cs
@@ -26,6 +26,10 @@ namespace NPoco
         public string ReferenceMemberName { get; set; }
         public MemberInfo MemberInfo { get; internal set; }
         public bool ExactColumnNameMatch { get; set; }
+        /// <summary>
+        /// If this is set, this column's members will not be mapped beyond [HardDepthLimit] iterations (useful for complex, long-looping or aggregate data structures)
+        /// </summary>
+        public int? HardDepthLimit {get;set;}
 
         public static ColumnInfo FromMemberInfo(MemberInfo mi)
         {
@@ -38,6 +42,7 @@ namespace NPoco
             var serializedColumnAttributes = attrs.OfType<SerializedColumnAttribute>().ToArray();
             var reference = attrs.OfType<ReferenceAttribute>().ToArray();
             var aliasColumn = attrs.OfType<AliasAttribute>().FirstOrDefault();
+            var depthLimit = attrs.OfType<DepthLimitAttribute>().FirstOrDefault();
 
             // Check if declaring poco has [ExplicitColumns] attribute
             var explicitColumns = mi.DeclaringType.GetTypeInfo().GetCustomAttributes(typeof(ExplicitColumnsAttribute), true).Any();
@@ -49,6 +54,9 @@ namespace NPoco
             {
                 ci.IgnoreColumn = true;
             }
+
+            if (depthLimit != null )
+                ci.HardDepthLimit = depthLimit.DepthLimit;
 
             if (complexMapping.Any())
             {

--- a/src/NPoco/DepthLimitAttribute.cs
+++ b/src/NPoco/DepthLimitAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace NPoco
+{
+    /// <summary>
+    /// Use to decorate columns, usually of lists, that have a chance of looping on themselves while being mapped
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class DepthLimitAttribute : Attribute
+    {
+        /// <summary>
+        /// Default constructor sets the depth limit to 1, which is - do not map beyond one iteration.
+        /// </summary>
+        public DepthLimitAttribute() 
+        {
+            DepthLimit = 1;
+        }
+        public DepthLimitAttribute(int maxDepth) 
+        {
+            if (maxDepth < 1) throw new ArgumentOutOfRangeException("maxDepth", "Hard depth limit should be at least equal to 1");
+            DepthLimit = maxDepth; 
+        }
+        public int DepthLimit { get; set; }
+    }
+}

--- a/src/NPoco/FluentMappings/ColumnConfigurationBuilder.cs
+++ b/src/NPoco/FluentMappings/ColumnConfigurationBuilder.cs
@@ -61,6 +61,7 @@ namespace NPoco.FluentMappings
         IManyColumnBuilder<TModel> WithDbType(Type type);
         IManyColumnBuilder<TModel> WithDbType<T>();
         IManyColumnBuilder<TModel> Reference(Expression<Func<TModel, object>> member);
+        IManyColumnBuilder<TModel> LimitMappingDepth(int limit = 1);        
     }
 
     public class ManyColumnBuilder<TModel> : IManyColumnBuilder<TModel>
@@ -96,6 +97,20 @@ namespace NPoco.FluentMappings
             _columnDefinition.ReferenceMember = MemberHelper<TModel>.GetMembers(member).Last();
             return this;
         }
+        /// <summary>
+        /// Sets the hard mapping depth limit for this column's definition
+        /// </summary>
+        /// <param name="limit">integer hard depth limit. Defaults to and can't be less than 1</param>
+        /// <returns>The ManyColumnBuilder</returns>
+        public IManyColumnBuilder<TModel> LimitMappingDepth(int limit = 1)
+        {
+            if ( limit < 1 )
+                throw new ArgumentOutOfRangeException("limit", "The mapping depth limit must always be at least equal to 1");
+
+                _columnDefinition.HardDepthLimit = limit;
+
+                return this;
+        }
     }
 
     public interface IColumnBuilder<TModel>
@@ -118,6 +133,7 @@ namespace NPoco.FluentMappings
         IColumnBuilder<TModel> ValueObject();
         IColumnBuilder<TModel> ValueObject(Expression<Func<TModel, object>> member);
         IColumnBuilder<TModel> ForceToUtc(bool enabled);
+        IColumnBuilder<TModel> LimitMappingDepth(int limit = 1);
     }
 
     public class ColumnBuilder<TModel> : IColumnBuilder<TModel>
@@ -253,5 +269,19 @@ namespace NPoco.FluentMappings
             _columnDefinition.ForceUtc = enabled;
             return this;
         }
+        /// <summary>
+        /// Sets the hard mapping depth limit for this column's definition
+        /// </summary>
+        /// <param name="limit">integer hard depth limit. Defaults to and can't be less than 1</param>
+        /// <returns>The ColumnBuilder</returns>
+        public IColumnBuilder<TModel> LimitMappingDepth(int limit = 1)
+        {
+            if ( limit < 1 )
+                throw new ArgumentOutOfRangeException("limit", "The mapping depth limit must always be at least equal to 1");
+
+                _columnDefinition.HardDepthLimit = limit;
+
+            return this;
+        }        
     }
 }

--- a/src/NPoco/FluentMappings/ColumnDefinition.cs
+++ b/src/NPoco/FluentMappings/ColumnDefinition.cs
@@ -26,5 +26,9 @@ namespace NPoco.FluentMappings
         public bool? ValueObjectColumn { get; set; }
         public string ValueObjectColumnName { get; set; }
         public bool? ExactColumnNameMatch { get; set; }
+        /// <summary>
+        /// If this is set, this column's members will not be mapped beyond [HardDepthLimit] iterations (useful for complex, long-looping or aggregate data structures)
+        /// </summary>
+        public int? HardDepthLimit {get;set;}
     }
 }

--- a/src/NPoco/FluentMappings/ConventionScannerSettings.cs
+++ b/src/NPoco/FluentMappings/ConventionScannerSettings.cs
@@ -31,6 +31,10 @@ namespace NPoco.FluentMappings
         public Func<MemberInfo, string> DbColumnsNamed { get; set; }
         public Func<MemberInfo, string> AliasNamed { get; set; }
         public Func<MemberInfo, Type> DbColumnTypesAs { get; set; }
+        /// <summary>
+        /// Set the hard depth limit for the columns. Null leaves the limit unset.
+        /// </summary>
+        public Func<MemberInfo, int?> HardDepthLimitAs {get;set;}
         public List<Func<MemberInfo, bool>> IgnorePropertiesWhere { get; set; }
         public Func<MemberInfo, bool> VersionPropertiesWhere { get; set; }
         public Func<MemberInfo, VersionColumnType> VersionPropertyTypeAs { get; set; }

--- a/src/NPoco/FluentMappings/FluentMappingConfiguration.cs
+++ b/src/NPoco/FluentMappings/FluentMappingConfiguration.cs
@@ -113,10 +113,14 @@ namespace NPoco.FluentMappings
 
                     foreach (var columnDefinition in columnDefinitions)
                     {
+
+                        if ( columnDefinition.HardDepthLimit >= members.Count)
+                            continue;
+
                         yield return columnDefinition;
                     }
 
-                    var referenceDbColumnsNamed = scannerSettings.ReferenceDbColumnsNamed(member);
+                    var referenceDbColumnsNamed = scannerSettings.ReferenceDbColumnsNamed(member);                                        
 
                     yield return new ColumnDefinition()
                     {
@@ -128,6 +132,7 @@ namespace NPoco.FluentMappings
                         ReferenceMember = null,
                         ResultColumn = scannerSettings.ResultPropertiesWhere(member),
                         DbColumnName = referenceProperty ? referenceDbColumnsNamed : null,
+                        HardDepthLimit = scannerSettings.HardDepthLimitAs(member)
                     };
                 }
                 else
@@ -151,6 +156,7 @@ namespace NPoco.FluentMappings
                     columnDefinition.Serialized = scannerSettings.SerializedWhere(member);
                     columnDefinition.IsComplexMapping = scannerSettings.ComplexPropertiesWhere(member);
                     columnDefinition.ValueObjectColumn = scannerSettings.ValueObjectColumnWhere(member);
+                    columnDefinition.HardDepthLimit = scannerSettings.HardDepthLimitAs(member);
                     yield return columnDefinition;
                 }
             }
@@ -182,7 +188,8 @@ namespace NPoco.FluentMappings
                 DbColumnWhere = x => ReflectionUtils.GetCustomAttributes(x, typeof(ColumnAttribute)).Any(),
                 ValueObjectColumnWhere = x => x.GetMemberInfoType().GetInterfaces().Any(y => y == typeof(IValueObject)),
                 Lazy = false,
-                MapNestedTypesWhen = x => false
+                MapNestedTypesWhen = x => false,
+                HardDepthLimitAs = x => null //no depth limit by default
             };
             scanner.Invoke(new ConventionScanner(defaultScannerSettings));
             return defaultScannerSettings;
@@ -227,6 +234,7 @@ namespace NPoco.FluentMappings
                     columnDefinition.Value.ForceUtc = columnInfo.ForceToUtc;
                     columnDefinition.Value.Serialized = columnInfo.SerializedColumn;
                     columnDefinition.Value.ValueObjectColumn = columnInfo.ValueObjectColumn;
+                    columnDefinition.Value.HardDepthLimit = columnInfo.HardDepthLimit;
                 }
             }
         }
@@ -278,6 +286,7 @@ namespace NPoco.FluentMappings
                     convColDefinition.ValueObjectColumn = overrideColumnDefinition.Value.ValueObjectColumn ?? convColDefinition.ValueObjectColumn;
                     convColDefinition.ValueObjectColumnName = overrideColumnDefinition.Value.ValueObjectColumnName ?? convColDefinition.ValueObjectColumnName;
                     convColDefinition.ExactColumnNameMatch = overrideColumnDefinition.Value.ExactColumnNameMatch ?? convColDefinition.ExactColumnNameMatch;
+                    convColDefinition.HardDepthLimit = overrideColumnDefinition.Value.HardDepthLimit ?? convColDefinition.HardDepthLimit;
                 }
             }
         }

--- a/src/NPoco/FluentMappings/FluentMappingsPocoDataBuilder.cs
+++ b/src/NPoco/FluentMappings/FluentMappingsPocoDataBuilder.cs
@@ -116,6 +116,8 @@ namespace NPoco.FluentMappings
             if (isColumnDefined && (typeConfig.ColumnConfiguration[key].IgnoreColumn.HasValue && typeConfig.ColumnConfiguration[key].IgnoreColumn.Value))
                 columnInfo.IgnoreColumn = true;
 
+            if (isColumnDefined) columnInfo.HardDepthLimit = typeConfig.ColumnConfiguration[key].HardDepthLimit;
+
             // Work out the DB column name
             if (isColumnDefined)
             {


### PR DESCRIPTION
Adds the DepthLimit attribute and the ability to set depth limits in the Fluent Config.
If the DepthLimit is set for a specific column, that column will not explore all the possible branches but rather stop after computing all the paths with a maximum distance of N from its source. 

As an example, if you set it like:

`c.Column(m => m.MyProp).Reference( m => m.Id, ReferenceType.OneToOne).LimitMappingDepth(2)`

That means that it will explore all the members in MyProp, if it finds child members in MyChildProp it will explore those too, but then it will not go further away from MyProp (depth 2 reached).

The loop protection is still valid and in place, but this adds to it and is invaluable if you have data structures with several foreign keys that can branch, as the flattening of that tree can lead to hundreds of thousands of possible paths. 

Use as a typical NPoco column attribute or at the end of a Column or Many declaration in fluent config. 
