### PR TITLE
ParameterHelper: avoid threating Newtonsoft JObject/JToken as collect…

### DIFF
--- a/src/NPoco/ParameterHelper.cs
+++ b/src/NPoco/ParameterHelper.cs
@@ -90,7 +90,10 @@ namespace NPoco
             }
 
             // Expand collections to parameter lists
+            // Do not take in consideration special cases like Newtonsoft JObject/JToken (they implement IEnumerable..)
             if ((arg_val as System.Collections.IEnumerable) != null &&
+                !string.Equals(arg_val.GetType().Name, "JObject") &&
+                !string.Equals(arg_val.GetType().Name, "JToken") &&
                 (arg_val as string) == null &&
                 (arg_val as byte[]) == null)
             {

--- a/test/NPoco.Tests/ParameterHelper.cs
+++ b/test/NPoco.Tests/ParameterHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace NPoco.Tests
@@ -117,6 +119,20 @@ namespace NPoco.Tests
 
             Assert.AreEqual(2, args.Count);
             Assert.AreEqual(resultSql, "SELECT * FROM test WHERE testID in (@0, @1, @0, @0, @1)");
+        }
+        
+        [Test]
+        public void JTokenCase()
+        {
+            var sql = "UPDATE test SET name = @0, data = @1 WHERE id = @2";
+            var reuseParameters = false;
+            var args = new List<object>();
+            var data = JToken.Parse("{\"Test\":\"Test\",\"Quantity\":5}");
+            var args_src = new object[] { "test", data,  Guid.NewGuid() };
+            var resultSql = ParameterHelper.ProcessParams(sql, args_src, args, reuseParameters);
+
+            Assert.AreEqual(3, args.Count);
+            Assert.AreEqual(resultSql, "UPDATE test SET name = @0, data = @1 WHERE id = @2");
         }
     }
 }


### PR DESCRIPTION
The ParameterHelper.ProcessParam function threat a JObject parameter as a collection of parameters because.. JObject implement IEnumerable.
This cause an issue when I try to update an entity/table with a property that contains a JToken or JObject property.
The solution is far from elegant but it works.
I added a test  to check it.

Please see the Issue #636 

Thank you