### PR TITLE
Use converters for ExecuteScalar calls

### DIFF
--- a/src/NPoco/Database.cs
+++ b/src/NPoco/Database.cs
@@ -632,7 +632,11 @@ namespace NPoco
                     Type t = typeof(T);
                     Type u = Nullable.GetUnderlyingType(t);
 
-                    return (T)Convert.ChangeType(val, u ?? t);
+                    var converter = MappingHelper.GetConverter(Mappers, null, val.GetType(), u ?? t);
+
+                    return converter != null
+                        ? (T)converter.Invoke(val)
+                        : (T)Convert.ChangeType(val, u ?? t);
                 }
             }
             catch (Exception x)


### PR DESCRIPTION
With this update, rather than just trying to convert an ExecuteScalar result type using `Converter.ChangeType` it uses the mappers registered with the database to allow more fine grained conversions. This will be useful for things like SQLite where it stores Guids as strings, but there is no direct conversion between string and Guid in C# so this would result in an exception, where as with this fix, an explicit converter can be added (or actually in this partiaucalr example, there is code in the mapping helper to handle this exact string > Guid scenario)

This fixes #664 