### PR TITLE
Reuse expression parameter if value has already been seen.

### DIFF
--- a/src/NPoco/Expressions/SqlExpression.cs
+++ b/src/NPoco/Expressions/SqlExpression.cs
@@ -1092,6 +1092,11 @@ namespace NPoco.Expressions
 
         protected string CreateParam(object value)
         {
+            // If value has already been provided, reuse the parameter.
+            var indexOfExistingValue = _params.IndexOf(value);
+            if (indexOfExistingValue >= 0)
+                return paramPrefix + indexOfExistingValue;
+
             string paramPlaceholder = paramPrefix + _params.Count;
             _params.Add(value);
             return paramPlaceholder;


### PR DESCRIPTION
This is my solution for #670. This works in the same way for SqlExpression evaluation as SqlBuilder's ReuseParameters, except it is always on.

This is helpful for e.g. search parameters. Currently, `query.Where(x => x.Field1.Contains(search) || x.Field2.Contains(search) || x.Field3.Contains(search))` will duplicate the search parameter each time, resulting in a WHERE clause looking like `WHERE [Field1] LIKE '@0' OR [Field2] LIKE '@1' OR [Field3] LIKE '@2'`.

With this change applied, this example would become  `WHERE [Field1] LIKE '@0' OR [Field2] LIKE '@0' OR [Field3] LIKE '@0'`.