### PR TITLE
Add support for Mappers in Linq queries for Where clauses in lambda and unary expressions

### DIFF
--- a/test/NPoco.Tests/Common/BaseDBDecoratedTest.cs
+++ b/test/NPoco.Tests/Common/BaseDBDecoratedTest.cs
@@ -40,6 +40,7 @@ namespace NPoco.Tests.Common
                     var dataSource = configuration.GetSection("TestDbDataSource").Value;
                     TestDatabase = new SQLLocalDatabase(dataSource);
                     Database = new Database(TestDatabase.Connection, new SqlServer2008DatabaseType() { UseOutputClause = false }, IsolationLevel.ReadUncommitted); // Need read uncommitted for the transaction tests
+                    Database.Mappers.Insert(0, new SqlTestDefaultMapper());
                     break;
 
                 case 3: // SQL Server

--- a/test/NPoco.Tests/Common/BaseDBFluentTest.cs
+++ b/test/NPoco.Tests/Common/BaseDBFluentTest.cs
@@ -161,7 +161,8 @@ namespace NPoco.Tests.Common
                         City = "City " + i
                     },
                     TestEnum = (i + 1) % 2 == 0 ? TestEnum.All : TestEnum.None,
-                    StringObject = new StringObject { MyValue = (i % 2) == 0 ? "Even" : "Odd" }
+                    StringObject = new StringObject { MyValue = (i % 2) == 0 ? "Even" : "Odd" },
+                    YorNBoolean = i % 3 == 0
                 };
                 Database.Insert(user);
                 InMemoryUsers.Add(user);

--- a/test/NPoco.Tests/Common/FirebirdDefaultMapper.cs
+++ b/test/NPoco.Tests/Common/FirebirdDefaultMapper.cs
@@ -42,6 +42,11 @@ namespace NPoco.Tests.Common
                 return src => new StringObject { MyValue = src?.ToString() };
             }
 
+            if ((DestType == typeof(bool)) && (SourceType == typeof(string)))
+            {
+                return src => !string.IsNullOrEmpty(src.ToString()) && src.ToString()[0] == 'Y';
+            }
+
             return base.GetFromDbConverter(DestType, SourceType);
         }
 
@@ -50,6 +55,11 @@ namespace NPoco.Tests.Common
             if ((sourceMemberInfo.GetMemberInfoType() == typeof(StringObject)) && (destType == typeof(string)))
             {
                 return src => ((StringObject)(src))?.ToString();
+            }
+
+            if (sourceMemberInfo?.Name == "YorNBoolean")
+            {
+                return src => (bool)src ? "Y" : "N";
             }
 
             return base.GetToDbConverter(destType, sourceMemberInfo);

--- a/test/NPoco.Tests/Common/SQLLocalDatabase.cs
+++ b/test/NPoco.Tests/Common/SQLLocalDatabase.cs
@@ -104,7 +104,8 @@ namespace NPoco.Tests.Common
                     YorN char NULL,
                     Address__Street nvarchar(50) NULL,
                     Address__City nvarchar(50) NULL,
-                    StringObject nvarchar(50) NULL
+                    StringObject nvarchar(50) NULL,
+                    YorNBoolean char default('Y') NOT NULL ,
                 );
             ";
             cmd.ExecuteNonQuery();

--- a/test/NPoco.Tests/Common/User.cs
+++ b/test/NPoco.Tests/Common/User.cs
@@ -34,6 +34,8 @@ namespace NPoco.Tests.Common
 
         public StringObject StringObject { get; set; }
 
+        public bool YorNBoolean { get; set; }
+
         //[ResultColumn]
         //public Supervisor Supervisor { get; set; }
     }

--- a/test/NPoco.Tests/FluentTests/QueryTests/ExpressionFluentTests.cs
+++ b/test/NPoco.Tests/FluentTests/QueryTests/ExpressionFluentTests.cs
@@ -279,6 +279,22 @@ namespace NPoco.Tests.FluentTests.QueryTests
         }
 
         [Test]
+        public void FetchWithWhereLambdaExpressionUsingMapper()
+        {
+            var users = Database.Query<User>().Where(x => x.YorNBoolean).ToList();
+
+            Assert.AreEqual(5, users.Count);
+        }
+
+        [Test]
+        public void FetchWithWhereUnaryExpressionUsingMapper()
+        {
+            var users = Database.Query<User>().Where(x => !x.YorNBoolean).ToList();
+
+            Assert.AreEqual(10, users.Count);
+        }
+
+        [Test]
         public void FetchWithWhereExpressionInAsStaticMethod()
         {
             var list = new[] {1, 2, 3, 4};


### PR DESCRIPTION
It fixes where clauses like:
.Where(x => x.Enabled)
.Where(x => !x.Enabled)