### PR TITLE
Fix detection of Sqlite connections

### DIFF
--- a/src/NPoco/DatabaseType.cs
+++ b/src/NPoco/DatabaseType.cs
@@ -267,7 +267,7 @@ namespace NPoco
                 return Singleton<OracleDatabaseType>.Instance;
             if (typeName.StartsWith("Oracle"))
                 return Singleton<OracleDatabaseType>.Instance;
-            if (typeName.StartsWith("SQLite"))
+            if (typeName.StartsWith("SQLite", StringComparison.OrdinalIgnoreCase))
                 return Singleton<SQLiteDatabaseType>.Instance;
             if (typeName.StartsWith("SqlConnection"))
                 return DynamicDatabaseType.MakeSqlServerType("SqlServerDatabaseType");


### PR DESCRIPTION
Non-capitalized class names should be detected in the same way as capitalized ones.
Fixes #687