### PR TITLE
Add missing async variants

### DIFF
--- a/src/NPoco/AsyncTransaction.cs
+++ b/src/NPoco/AsyncTransaction.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Data;
+using System.Threading.Tasks;
+
+namespace NPoco
+{
+    public class AsyncTransaction : IAsyncTransaction
+    {
+        IDatabase _db;
+        readonly IsolationLevel _isolationLevel;
+
+        public AsyncTransaction(IDatabase db, IsolationLevel isolationLevel)
+        {
+            _db = db;
+            _isolationLevel = isolationLevel;
+        }
+
+        public Task BeginAsync()
+        {
+            return _db.BeginTransactionAsync(_isolationLevel);
+        }
+
+        public async Task CompleteAsync()
+        {
+            await _db.CompleteTransactionAsync();
+            _db = null;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_db != null)
+            {
+                await _db.AbortTransactionAsync();
+            }
+        }
+    }
+
+    public interface IAsyncTransaction : IAsyncDisposable
+    {
+        Task CompleteAsync();
+    }
+}

--- a/src/NPoco/IBaseDatabase.cs
+++ b/src/NPoco/IBaseDatabase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Threading.Tasks;
 
 namespace NPoco
 {
@@ -43,6 +44,16 @@ namespace NPoco
         ITransaction GetTransaction(IsolationLevel isolationLevel);
 
         /// <summary>
+        /// Begins a new transaction and returns IAsyncTransaction which can be used in a await using statement
+        /// </summary>
+        Task<IAsyncTransaction> GetTransactionAsync();
+
+        /// <summary>
+        /// Begins a new transaction and returns IAsyncTransaction which can be used in a await using statement
+        /// </summary>
+        Task<IAsyncTransaction> GetTransactionAsync(IsolationLevel isolationLevel);
+
+        /// <summary>
         /// A data bag to store whatever you like per IDatabase instance
         /// </summary>        
         IDictionary<string, object> Data { get; }
@@ -63,9 +74,24 @@ namespace NPoco
         void BeginTransaction(IsolationLevel isolationLevel);
 
         /// <summary>
+        /// Manually begin a transaction. Recommended to use GetTransactionAsync
+        /// </summary>
+        Task BeginTransactionAsync();
+
+        /// <summary>
+        /// Manually begin a transaction. Recommended to use GetTransactionAsync
+        /// </summary>
+        Task BeginTransactionAsync(IsolationLevel isolationLevel);
+
+        /// <summary>
         /// Manually abort/rollback a transaction
         /// </summary>        
         void AbortTransaction();
+
+        /// <summary>
+        /// Manually abort/rollback a transaction
+        /// </summary>
+        Task AbortTransactionAsync();
 
         /// <summary>
         /// Manually commit a transaction
@@ -73,14 +99,29 @@ namespace NPoco
         void CompleteTransaction();
 
         /// <summary>
+        /// Manually commit a transaction
+        /// </summary>
+        Task CompleteTransactionAsync();
+
+        /// <summary>
         /// Opens the DbConnection manually
         /// </summary>
         IDatabase OpenSharedConnection();
 
         /// <summary>
+        /// Opens the DbConnection manually
+        /// </summary>
+        Task<IDatabase> OpenSharedConnectionAsync();
+
+        /// <summary>
         /// Closes the DBConnection manually
         /// </summary>
         void CloseSharedConnection();
+
+        /// <summary>
+        /// Closes the DBConnection manually
+        /// </summary>
+        Task CloseSharedConnectionAsync();
 
         /// <summary>
         /// Sets command timeout for the lifetime of the Database instance


### PR DESCRIPTION
# TLTR

`Database.OpenSharedConnectionImp` calls the synchronous `Open` method on the underlying `DbConnection`. In the case of MySqlConnector that initializes a connection in `IOBehavior.Synchronous` mode, which apparently can lead to locking issues.

In order to consistently call `OpenAsync` on the underlying `DbConnection` I had to implement several asynchronous alternatives of existing methods.

# Background

We've been using `NPoco` in production for many years. Lately (probably due to increasing load on our server) we've started seeing freezes of our server application where all DB operations would block.

Analyzing a a core dump of the frozen state hints towards a locking situation caused by mixing synchronous and asynchronous code:

![image](https://github.com/user-attachments/assets/6037f56d-5cd8-48a5-9450-c85de5feb58b)

This is the offending stack trace:

![image](https://github.com/user-attachments/assets/5d85a4f5-ec82-480e-a2d6-d220a84a7bbe)

As you can see, MySqlConnector uses the synchronous implementation of `ReadBytesAsync`. That's because the entire connection is operating in `IOBehavior.Synchronous` mode when it was opened with the synchronous `Open` function.

![image](https://github.com/user-attachments/assets/0c08d962-0fe1-4347-849e-b54b2ffd5932)

![image](https://github.com/user-attachments/assets/8ec3c57e-54f1-4a76-95e7-686c24639f31)

The solution is to call `OpenAsync` instead from within `Database.OpenSharedConnectionImp`. In order to achieve that I had to add several asynchronous alternatives to existing methods in your library.

# PR based on old code base

Unfortunately here on GitHub is a pretty old state of the code. If you agree with the general direction of this PR, could you please push the latest tags to GitHub so I can apply my changes to the latest code base?