### PR TITLE
Add HasChanges() to Snapshot<T> for efficient change detection

### DIFF
--- a/src/NPoco.Abstractions/Snapshotter.cs
+++ b/src/NPoco.Abstractions/Snapshotter.cs
@@ -83,6 +83,19 @@ namespace NPoco
             return list;
         }
 
+        public bool HasChanges()
+        {
+            foreach (var pocoColumn in _originalValues)
+            {
+                var newValue = pocoColumn.Key.GetColumnValue(_pocoData, _trackedObject);
+                if (!AreEqual(pocoColumn.Value, newValue))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         private bool AreEqual(object first, object second)
         {
             if (first == null && second == null) return true;

--- a/test/NPoco.Tests/SnapshotterTests.cs
+++ b/test/NPoco.Tests/SnapshotterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Microsoft.Data.SqlClient;
 using System.Linq;
-using NPoco;
 using NPoco.FluentMappings;
 using NPoco.Tests.Common;
 using NUnit.Framework;
@@ -147,6 +146,32 @@ namespace NPoco.Tests
             Assert.AreEqual(1, snap.Changes().Count);
             Assert.AreEqual(1, snap.UpdatedColumns().Count);
             Assert.AreEqual("Values", snap.UpdatedColumns()[0]);
+        }
+
+        [Test]
+        public void HasChangesShouldReturnFalseWhenNoChanges()
+        {
+            var user = new Admin { UserId = 1 };
+            var snap = _database.StartSnapshot(user);
+            Assert.False(snap.HasChanges());
+        }
+
+        [Test]
+        public void HasChangesShouldReturnTrueWhenPropertyChanged()
+        {
+            var user = new Admin { UserId = 1, Age = 30 };
+            var snap = _database.StartSnapshot(user);
+            user.Age = 31;
+            Assert.True(snap.HasChanges());
+        }
+
+        [Test]
+        public void HasChangesShouldMatchChangesCountBehavior()
+        {
+            var user = new Admin { UserId = 1, Age = 30 };
+            var snap = _database.StartSnapshot(user);
+            user.Age = 31;
+            Assert.AreEqual(snap.Changes().Any(), snap.HasChanges());
         }
     }
 


### PR DESCRIPTION
Currently, Snapshot<T> exposes Changes() and UpdatedColumns(), but there’s no direct way to check if any changes exist without calling Changes().Count > 0 or Changes().Any().

- This PR adds a convenience method HasChanges() with an **early-exit loop** to Snapshot<T> that improves code readability and avoids unnecessary allocation of a List<Change> when only a boolean check is needed.

Example

Before:
```csharp
if (snapshot.Changes().Count > 0) // Or .Changes().Any()
{
    db.Update(obj, snapshot.UpdatedColumns());
}
```

After:
```csharp
if (snapshot.HasChanges())
{
    db.Update(obj, snapshot.UpdatedColumns());
}
```

#Tests
Added unit tests in SnapshotTests verifying:

- HasChanges returns false when no changes are made.
- HasChanges returns true when tracked object values are updated.
- HasChanges reutrns the same as Changes().Any()